### PR TITLE
Link added for .NET Fiddle

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ Thanks to all [contributors](https://github.com/quozd/awesome-dotnet/graphs/cont
 ## Misc
 
 * [AzureCrawler](https://github.com/yagopv/AzureCrawler) - Take HTML Snapshots for your Angular, Ember, Durandal or any JavaScript applications
+* [.NET Fiddle](https://dotnetfiddle.net/) - Write, compile and run C# code in the browser. The C# equivalent of JSFiddle.
 
 ## ORM
 


### PR DESCRIPTION
A great browser based tool for writing blocks of C# code, the equivalent of JSfiddle but for C#.
