### PR TITLE
Application templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Thanks to all [contributors](https://github.com/quozd/awesome-dotnet/graphs/cont
 * [Awesome DotNet](#awesome-dotnet)
   * [API](#api)
   * [Application Frameworks](#application-frameworks)
+  * [Application Templates](#application-templates)
   * [Assembly Manipulation](#assembly-manipulation)
   * [Assets](#assets)
   * [Authentication and Authorization](#authentication-and-authorization)
@@ -95,6 +96,10 @@ Thanks to all [contributors](https://github.com/quozd/awesome-dotnet/graphs/cont
 * [Mono](https://github.com/mono/mono) - Mono open source ECMA CLI, C# and .NET implementation
 * [Mono-Addins](https://github.com/mono/mono-addins) - Mono.Addins is a generic framework for creating extensible applications, and for creating add-ins which extend those applications
 * [Spring.Net](https://github.com/spring-projects/spring-net) - Spring.NET is an open source application framework that makes building  enterprise .NET applications easier
+
+## Application Templates
+
+* [MVC.Template](https://github.com/NonFactors/MVC.Template) - ASP.NET MVC 5 project starter template
 
 ## Assembly Manipulation
 


### PR DESCRIPTION
Added application templates section with a ASP.NET MVC 5 template project which is actively maintained and hopefully has a clean code structure (can't judge myself I guess :smile:).

I suppose that ASP.NET Boilerplate could be moved from frameworks to templates too?