### PR TITLE
Adding DotImaging framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,7 @@ Thanks to all [contributors](https://github.com/quozd/awesome-dotnet/graphs/cont
 
 * [ImageResizer](http://imageresizing.net/) - Add commands to image URLs to get altered versions in milliseconds. Resizing, editing etc of images in real-time.
 * [ImageProcessor](http://imageprocessor.org/) - Open-source .NET library to manipulate images on-the-fly.
+* [DotImaging](https://github.com/dajuric/dot-imaging) - The only .NET image IO framework you need.
 
 ## Install tools
 


### PR DESCRIPTION
The framework sets focus on .NET native array as primary imaging object, offers extensibility support via extensions, and provides unified platform-abstract imaging IO API. The roots of the framework can be found in https://github.com/dajuric/accord-net-extensions which is already on the list.