### PR TITLE
add Micro Framework category and NETMF interpreter

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Thanks to all [contributors](https://github.com/quozd/awesome-dotnet/graphs/cont
   * [Mathematics](#mathematics)
   * [Media](#media)
   * [Metrics](#metrics)
+  * [Micro Framework](#micro-framework)
   * [Misc](#misc)
   * [MVVM](#mvvm)
   * [Office](#office)
@@ -422,6 +423,9 @@ metadata in media files, including video, audio, and photo formats
 ## Metrics
 
 * [C# StatsD Client](https://github.com/goncalopereira/statsd-csharp-client) - C# client for Etsy's StatsD
+
+## Micro Framework
+* [.NET Micro Framework Interpreter](https://github.com/NETMF/netmf-interpreter) - Microsoft® .NET Micro Framework (NETMF) for developing embedded applications on small devices using Visual Studio
 
 ## Misc
 * [.NET Fiddle](https://dotnetfiddle.net/) - Write, compile and run C# code in the browser. The C# equivalent of JSFiddle.


### PR DESCRIPTION
Hey,
I'd love to add some .NET Micro Framework projects to at least show it exists and lives (again!), starting with [.NET Micro Framework itself](https://github.com/NETMF/netmf-interpreter).

If you don't know - NETMF is an IL interpreter from Microsoft for small embedded devices (let's say - Arduino class), and version 4.4 was just released (and it's on GH since a few months ago).

I've prepared a new category "Micro Framework" with a link to NETMF to it, is it ok?

The problem is, however, that many of libraries for NETMF aren't actively maintained anymore, so they won't pass through guidelines probably...