### PR TITLE
Added Minification category

### DIFF
--- a/README.md
+++ b/README.md
@@ -452,7 +452,6 @@ metadata in media files, including video, audio, and photo formats
 
 * [Microsoft Ajax Minifier](http://ajaxmin.codeplex.com/) - Contains JS and CSS minifiers which have a highest performance, because its have been specifically designed for .NET. Optionally produce Source Maps for JS code.
 * [Web Markup Minifier](http://webmarkupmin.codeplex.com/) - .NET library that contains a set of markup minifiers. The objective of this project is to improve the performance of web applications by reducing the size of HTML, XHTML and XML code.
-* [YUI Compressor for .NET](https://github.com/PureKrome/YUICompressor.NET) - .NET port of the Yahoo! UI Library's YUI Compressor Java project. The objective of this project is to minify any JS and CSS code to an efficient level that works exactly as the original source, before it was minified.
 
 ## Misc
 * [.NET Fiddle](https://dotnetfiddle.net/) - Write, compile and run C# code in the browser. The C# equivalent of JSFiddle.

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Thanks to all [contributors](https://github.com/quozd/awesome-dotnet/graphs/cont
   * [Media](#media)
   * [Metrics](#metrics)
   * [Micro Framework](#micro-framework)
+  * [Minification](#minification)
   * [Misc](#misc)
   * [MVVM](#mvvm)
   * [Office](#office)
@@ -446,6 +447,12 @@ metadata in media files, including video, audio, and photo formats
 
 ## Micro Framework
 * [.NET Micro Framework Interpreter](https://github.com/NETMF/netmf-interpreter) - Microsoft® .NET Micro Framework (NETMF) for developing embedded applications on small devices using Visual Studio
+
+## Minification
+
+* [Microsoft Ajax Minifier](http://ajaxmin.codeplex.com/) - Contains JS and CSS minifiers which have a highest performance, because its have been specifically designed for .NET. Optionally produce Source Maps for JS code.
+* [Web Markup Minifier](http://webmarkupmin.codeplex.com/) - .NET library that contains a set of markup minifiers. The objective of this project is to improve the performance of web applications by reducing the size of HTML, XHTML and XML code.
+* [YUI Compressor for .NET](https://github.com/PureKrome/YUICompressor.NET) - .NET port of the Yahoo! UI Library's YUI Compressor Java project. The objective of this project is to minify any JS and CSS code to an efficient level that works exactly as the original source, before it was minified.
 
 ## Misc
 * [.NET Fiddle](https://dotnetfiddle.net/) - Write, compile and run C# code in the browser. The C# equivalent of JSFiddle.


### PR DESCRIPTION
I propose to create the “Minification” category and add the following projects:

* [Microsoft Ajax Minifier](http://ajaxmin.codeplex.com/) - Contains JS and CSS minifiers which have a highest performance, because its have been specifically designed for .NET. Optionally produce Source Maps for JS code.
* [Web Markup Minifier](http://webmarkupmin.codeplex.com/) - .NET library that contains a set of markup minifiers. The objective of this project is to improve the performance of web applications by reducing the size of HTML, XHTML and XML code.