### PR TITLE
Adding DotImaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,6 +368,7 @@ Thanks to all [contributors](https://github.com/quozd/awesome-dotnet/graphs/cont
 * [DynamicImage](http://dynamicimage.apphb.com/) - High-performance open-source image manipulation library for ASP.NET.
 * [MetadataExtractor](https://github.com/drewnoakes/metadata-extractor-dotnet) - Extracts Exif, IPTC, XMP, ICC and other metadata from image files.
 * [Emgu CV](http://www.emgu.com/wiki/index.php/Main_Page) - Cross-platform .NET wrapper for the OpenCV library.
+* [DotImaging](https://github.com/dajuric/dot-imaging) - Minimalistic .NET imaging portable platform
 
 ## Install tools
 


### PR DESCRIPTION
DotImaging - .NET array as imaging object
The framework sets focus on .NET native array as primary imaging object, offers extensibility support via extensions, and provides unified platform-abstract imaging IO API.