### PR TITLE
Add Fable

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ Thanks to all [contributors](https://github.com/quozd/awesome-dotnet/graphs/cont
 * [Netjs](https://github.com/praeclarum/Netjs) - .NET to TypeScript and JavaScript compiler. Portable Class Libraries work great for this. You can even pass EXEs.
 * [Roslyn](https://github.com/dotnet/roslyn) - The .NET Compiler Platform ("Roslyn") provides open-source C# and Visual Basic compilers with rich code analysis APIs. It enables building code analysis tools with the same APIs that are used by Visual Studio.
 * [VisualFSharp](https://github.com/Microsoft/visualfsharp) - The Visual F# compiler and tools
+* [Fable](https://github.com/fsprojects/Fable) - F# to JavaScript Compiler
 
 ## Compression
 


### PR DESCRIPTION
fsprojects/Fable - [https://github.com/fsprojects/Fable](https://github.com/fsprojects/Fable)

Fable brings together the power of the F# compiler and Babel to make JavaScript a true backend for F#. Some of its main features are:

- Works directly on F# source code, no compilation to .NET bytecode needed
- Optimizes F# code to generate as clean JavaScript as possible
- Passes location data to Babel to generate source maps
- Compatible with all Babel plugins and other JS development tools, like Webpack
- Support for most of the F# core library and a bit of .NET Base Class Library
- Tiny core library included (less than 10KB minified and gzipped) with no runtime
- Organizes code using ES6 modules
- Interacts seamlessly with other JavaScript libraries
- Bonus: compile NUnit tests to Mocha

