### PR TITLE
Added Cryptography/Pkcs11Interop

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ Thanks to all [contributors](https://github.com/quozd/awesome-dotnet/graphs/cont
 * [BouncyCastle](https://bouncycastle.org/) - Together with the .Net System.Security.Cryptography, the reference implementation for cryptographic algorithms on the CLR.
 * [HashLib](http://hashlib.codeplex.com/) - HashLib is a collection of nearly all hash algorithms you've ever seen, it supports almost everything and is very easy to use
 * [libsodium-net](https://github.com/adamcaudill/libsodium-net) - libsodium for .NET - A secure cryptographic library
+* [Pkcs11Interop](https://github.com/Pkcs11Interop/Pkcs11Interop) - Managed .NET wrapper for unmanaged PKCS#11 libraries that provide access to the cryptographic hardware
 * [StreamCryptor](https://github.com/bitbeans/StreamCryptor) - Stream encryption & decryption with libsodium and protobuf
 
 ## Database


### PR DESCRIPTION
Cryptography/Pkcs11Interop - [https://www.pkcs11interop.net/](https://www.pkcs11interop.net/)

Pkcs11Interop is managed library written in C# that brings full power of PKCS#11 API to the .NET environment. It loads unmanaged PKCS#11 library provided by the cryptographic device vendor and makes its functions accessible to .NET application.

Pkcs11Interop library:

* implements .NET wrapper for unmanaged PKCS#11 libraries
* is compliant with PKCS#11 v2.20 specification and PKCS#11 URI scheme defined in RFC 7512
* is compatible with .NET Framework 2.0 (and higher), Mono, Xamarin and Silverlight5
* is supported on Windows, Linux, Mac OS X, Android and iOS
* is supported on both 32-bit and 64-bit platforms
* is open source and completely free for commercial use
* is used in production by several information security and financial organizations
* uses 100% managed and fully documented code
* contains code samples covering all methods of PKCS#11 API