### PR TITLE
Adding Croniton

### DIFF
--- a/README.md
+++ b/README.md
@@ -578,6 +578,7 @@ metadata in media files, including video, audio, and photo formats
 * [NCrontab](https://github.com/atifaziz/NCrontab) - Class library for parsing & formatting [crontab](http://crontab.org/) expressions as well as calculating occurrences of time based on a crontab schedule
 * [QuartzNet](https://github.com/quartznet/quartznet) - Quartz Enterprise Scheduler .NET
 * [Hangfire] (https://github.com/HangfireIO) - An easy way to perform fire-and-forget, delayed and recurring tasks inside .NET apps
+* [Chroniton] (https://github.com/leosperry/Chroniton) - A simple, fully integrable, and customizable library for running strongly typed jobs (tasks) on schedules.
 
 ## SDK and API Clients
 


### PR DESCRIPTION
Scheduling/Chroniton- [https://github.com/leosperry/Chroniton](https://github.com/leosperry/Chroniton)

A simple, fully integrable, and customizable library for running strongly typed jobs (tasks) on schedules.
