### PR TITLE
Fixed link for Metrics.NET

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ Thanks to all [contributors](https://github.com/quozd/awesome-dotnet/graphs/cont
 * [CodeMaid](http://www.codemaid.net/) - Visual studio extension to cleanup, dig through and simplify C#, C++, F#, VB, PHP, JSON, XAML, XML, ASP, HTML, CSS, LESS, SCSS, JavaScript and TypeScript coding.
 * [StyleCop](https://stylecop.codeplex.com/) - StyleCop analyzes C# source code to enforce a set of style and consistency rules
 * [Gendarme](https://github.com/spouliot/gendarme) - Extensible rule-based tool to find problems in .NET applications and libraries
-* [Metrics-Net](https://github.com/Recognos/metrics-net) - Capturing CLR and application-level metrics. So you know what's going on.
+* [Metrics-Net](https://github.com/Recognos/Metrics.NET) - Capturing CLR and application-level metrics. So you know what's going on.
 * [BenchmarkDotNet](https://github.com/PerfDotNet/BenchmarkDotNet) - Powerful .NET library for benchmarking.
 
 ## Compiler

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ Thanks to all [contributors](https://github.com/quozd/awesome-dotnet/graphs/cont
 * [CodeMaid](http://www.codemaid.net/) - Visual studio extension to cleanup, dig through and simplify C#, C++, F#, VB, PHP, JSON, XAML, XML, ASP, HTML, CSS, LESS, SCSS, JavaScript and TypeScript coding.
 * [StyleCop](https://stylecop.codeplex.com/) - StyleCop analyzes C# source code to enforce a set of style and consistency rules
 * [Gendarme](https://github.com/spouliot/gendarme) - Extensible rule-based tool to find problems in .NET applications and libraries
-* [Metrics-Net](https://github.com/danielcrenna/metrics-net) - Capturing CLR and application-level metrics. So you know what's going on.
+* [Metrics-Net](https://github.com/Recognos/metrics-net) - Capturing CLR and application-level metrics. So you know what's going on.
 * [BenchmarkDotNet](https://github.com/PerfDotNet/BenchmarkDotNet) - Powerful .NET library for benchmarking.
 
 ## Compiler


### PR DESCRIPTION
Code Analysis and Metrics/Metrics-Net

It looks like this project has moved to a new URL. The new maintainer posted a message about it here: https://github.com/etishor/Metrics.NET/issues/122#issuecomment-184707498. The previous owner of the repo where this was forked from has passed away: https://github.com/etishor/Metrics.NET/issues/122#issuecomment-175175100. The NuGet package (https://www.nuget.org/packages/Metrics.NET/0.3.7) now also uses this url.

