### PR TITLE
Remove OAuth library.

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,6 @@ Thanks to all [contributors](https://github.com/quozd/awesome-dotnet/graphs/cont
 * [Logibit Hawk](https://github.com/logibit/logibit.hawk/) - A F# [Hawk](https://github.com/hueniverse/hawk#usage-example) authentication library
 * [IdentityModel](https://github.com/IdentityModel) - Helper library for identity & access control in .NET 4.5 and MVC4/Web API.
 * [IdentityServer](https://github.com/IdentityServer) - Extensible OAuth2 and OpenID Connect provider framework.
-* [OAuth](https://github.com/danielcrenna/oauth) - A very lightweight library for generating OAuth 1.0a signatures written in C#
 
 ## Build Automation
 


### PR DESCRIPTION
The OAuth library from @danielcrenna can't be found, may be he deleted it. So I think that now it should be removed, as it is causing our builds to fail.


/cc @quozd @Jeffiy 