### PR TITLE
Add ASP.NET Core Library and Framework Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -709,6 +709,7 @@ metadata in media files, including video, audio, and photo formats
 * [awesome-LINQ](https://github.com/aloisdg/awesome-linq) - A curated collection of awesome LINQ libraries, tools, and more.
 * [awesome-analyzers](https://github.com/Cybermaxs/awesome-analyzers) - A curated list of .NET Compiler Platform ("Roslyn") diagnostic analyzers and code fixes.
 * [C# Algorithms, Data Structures](https://github.com/aalhour/C-Sharp-Algorithms) - A list of algorithms and data structures implementations.
+* [ASP.NET Core Library and Framework Support](https://github.com/jpsingleton/ANCLAFS) - A list of what .NET libraries and frameworks are currently supported by ASP.NET Core and .NET Core (also at [ANCLAFS.com](https://anclafs.com/)).
 
 # Other Awesome Lists
 Other amazingly awesome lists can be found in the [awesome-awesomeness](https://github.com/bayandin/awesome-awesomeness) list.


### PR DESCRIPTION
Other Lists / ANCLAFS - [github.com/jpsingleton/ANCLAFS](https://github.com/jpsingleton/ANCLAFS)

ASP.NET Core Library and Framework Support - [ANCLAFS.com](https://ANCLAFS.com)

A list of what .NET libraries and frameworks are currently supported by ASP.NET Core and .NET Core (also at ANCLAFS.com).