### PR TITLE
Add Stubble to Template Engines

### DIFF
--- a/README.md
+++ b/README.md
@@ -629,6 +629,7 @@ metadata in media files, including video, audio, and photo formats
 
 * [RazorEngine](https://github.com/Antaris/RazorEngine) - Open source templating engine based on Microsoft's Razor parsing engine
 * [Nustache](https://github.com/jdiamond/Nustache) - Open source library for logic-less templates
+* [Stubble](https://github.com/stubbleorg/stubble) - Trimmed down {{mustache}} templates in .NET. Successor of Nustache.
 * [DotLiquid](https://github.com/dotliquid/dotliquid) - C# port of the Ruby Liquid templating language
 
 ## Testing


### PR DESCRIPTION
Template Engine/Stubble - [Stubble](https://github.com/stubbleorg/stubble)

PROJECT_DESCRIPTION
Stubble is an implementation of the Mustache template system in C# (but is usable from any .NET language).

Notes:
I'm the maintainer and contributor for Nustache and created Stubble to be a trimmed down, extensible and multi-platform successor to Nustache.