### PR TITLE
add Wire

### DIFF
--- a/README.md
+++ b/README.md
@@ -623,6 +623,7 @@ metadata in media files, including video, audio, and photo formats
 * [ProtoBuf](https://github.com/hultqvist/ProtoBuf) - Generate C# code for protocol buffer serialization from a .proto specification.
 * [F# Data](http://fsharp.github.io/FSharp.Data/) - F# type providers for accessing XML, JSON, CSV and HTML files (based on sample documents) and for accessing WorldBank data
 * [Bond](https://github.com/Microsoft/bond) - cross-platform framework for working with schematized data. It supports cross-language de/serialization and powerful generic mechanisms for efficiently manipulating data.
+* [Wire](https://github.com/akkadotnet/Wire) - Binary serializer for POCO objects
 
 ## State machines
 


### PR DESCRIPTION
Serialization/Wire - [https://github.com/akkadotnet/Wire](https://github.com/akkadotnet/Wire)

Binary serializer for POCO objects from Akka.Net creator

