### PR TITLE
add kestrel

### DIFF
--- a/README.md
+++ b/README.md
@@ -707,6 +707,7 @@ metadata in media files, including video, audio, and photo formats
 
 ## Web Servers
 
+* [Kestrel](https://github.com/aspnet/KestrelHttpServer) -  A web server for ASP.NET Core based on libuv
 * [EmbedIO](https://github.com/unosquare/embedio) - Web server built on Mono and cross-platform
 * [Jexus web server](http://www.jexus.org) - Web server for Linux
 * [XSP](https://github.com/mono/xsp) - Mono's ASP.NET hosting server. This module includes an Apache Module, a FastCGI module that can be hooked to other web servers as well as a standalone server used for testing (similar to Microsoft's Cassini)


### PR DESCRIPTION
Web Servers/Kestrel- [https://github.com/aspnet/KestrelHttpServer](https://github.com/aspnet/KestrelHttpServer)

A web server for ASP.NET Core based on libuv.

