### PR TITLE
add typeshape

### DIFF
--- a/README.md
+++ b/README.md
@@ -511,6 +511,7 @@ metadata in media files, including video, audio, and photo formats
 * [Jint](https://github.com/sebastienros/jint) - Javascript interpreter for .NET which provides full ECMA 5.1 compliance and can run on any .NET plaftform.
 * [MSBuild ILMerge task](https://ilmergemsbuild.codeplex.com/) - MSBuild ILMerge task is a NuGet package allows you to use the famous ILMerge utility in automated builds and/or Visual Studio projects.
 * [ReactJS.NET](https://github.com/reactjs/React.NET) - ReactJS.NET is a library that makes it easier to use Babel along with Facebook's React and JSX from C#.
+* [TypeShape](https://github.com/eiriktsarpalis/TypeShape) - TypeShape is a small, extensible F# library for practical generic programming
 
 ## MVVM
 


### PR DESCRIPTION
Misc/typeshape- [https://github.com/eiriktsarpalis/TypeShape](https://github.com/eiriktsarpalis/TypeShape)

TypeShape is a small, extensible F# library for practical generic programming. Borrowing from ideas used in the FsPickler implementation, it uses a combination of reflection, active patterns and F# object expressions to minimize the amount of reflection required by the user in such applications.

