### PR TITLE
Added markdig

### DIFF
--- a/README.md
+++ b/README.md
@@ -471,6 +471,7 @@ Thanks to all [contributors](https://github.com/quozd/awesome-dotnet/graphs/cont
 * [MarkdownSharp](https://code.google.com/archive/p/markdownsharp) - Open source C# implementation of Markdown processor, as featured on Stack Overflow.
 * [F# Formatting](http://tpetricek.github.io/FSharp.Formatting/) - Tools for documenting F# and C# projects.  The library contains extensible Markdown parser as a core component.
 * [CommonMark.NET](https://github.com/Knagis/CommonMark.NET) - Implementation of CommonMark specification in C# for converting Markdown documents to HTML. Optimized for maximum performance and portability.
+* [markdig](https://github.com/lunet-io/markdig) - A fast, powerful, CommonMark compliant, extensible Markdown processor for .NET.
 
 ## Mail
 


### PR DESCRIPTION
Markdown Processors/markdig - [https://github.com/lunet-io/markdig](https://github.com/lunet-io/markdig)

A fast, powerful, CommonMark compliant, extensible Markdown processor for .NET.