### PR TITLE
Add VSColorOutput to Visual Studio Extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -715,6 +715,7 @@ metadata in media files, including video, audio, and photo formats
 * [CodeContracts](https://github.com/Microsoft/CodeContracts) - Source code for the CodeContracts tools for .NET
 * [Git Diff Margin](https://github.com/laurentkempe/GitDiffMargin) - Displays live Git changes of the currently edited file on Visual Studio margin and scroll bar
 * [Productivity Power Tools](https://visualstudiogallery.msdn.microsoft.com/d0d33361-18e2-46c0-8ff2-4adea1e34fef) - A set of extensions to Visual Studio Professional (and above) which improves developer productivity.
+* [VSColorOutput](https://www.visualstudiogallery.msdn.microsoft.com/f4d9c2b5-d6d7-4543-a7a5-2d7ebabc2496) - Color highlighting for Build, Find and Debug output windows. Custom match patterns and colors can be added.
 
 ## Web Frameworks
 


### PR DESCRIPTION
Visual Studio Plugin/[VSColorOutput](https://github.com/mike-ward/VSColorOutput)

VSColorOutput is a Visual Studio extension that adds color highlighting to Visual Studio's Build and Debug Output Windows. Errors are in Red, Warnings in Yellow, build headers are Green.   
  
Custom match patterns can be added. Colors can be modified.  
  
Developed in C# and NUnit.  
  
An options page is used to add custom match expressions.  
