### PR TITLE
Add appccelerate command line parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ Thanks to all [contributors](https://github.com/quozd/awesome-dotnet/graphs/cont
 * [Fluent Command Line Parser](https://github.com/fclp/fluent-command-line-parser) - A simple, strongly typed .NET C# command line parser library using a fluent easy to use interface
 * [Power Args](https://github.com/adamabdelhamed/PowerArgs) - PowerArgs converts command line arguments into .NET objects that are easy to program against. It also provides a ton of optional capabilities such as argument validation, auto generated usage, tab completion, and plenty of extensibility
 * [Argu](https://github.com/fsprojects/Argu) - Declarative CLI argument & XML configuration parser for F# applications.
+* [Appccelerate - Command Line Parser](http://www.appccelerate.com/commandlineparser.html) - A command line parser with fluent definition syntax, different argument types, required and optional arguments, value restrictions, aliases, type conversion and semi-automatic usage help message composition   
 
 ## CLR
 


### PR DESCRIPTION
CLI/Appccelerate - Command Line Parser - [Appccelerate - Command Line Parser](http://www.appccelerate.com/commandlineparser.html)

Easy to use command line parser library with the following features:
* fluent definition syntax using lambdas
* named, positional and switch arguments
* required and optional arguments
* value restrictions
* alias
* type conversion
* semi-automatic composition of a usage help message

concise description see: http://www.appccelerate.com/commandlineparser.html

<!--
  Please, fill in this PR template. It will help maintainers to do the review.
  Also, please read our [Contribution guidelines](CONTRIBUTING.md). 
  Please, create one pull request per link.
-->

