### PR TITLE
Add ScintillaNET

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,6 +387,7 @@ Thanks to all [contributors](https://github.com/quozd/awesome-dotnet/graphs/cont
 * [SciterSharp](https://github.com/MISoftware/SciterSharp) - Create .NET cross-platform desktop apps using not just HTML, but all features of Sciter engine: CSS3, SVG, scripting, AJAX, &lt;video&gt;... Sciter is free for commercial use
 * [Empty Keys UI](http://emptykeys.com/ui_library) - Multi-platform and multi-engine XAML based user interface library **[Free][Proprietary]** 
 * [UWP Community Toolkit](https://github.com/Microsoft/UWPCommunityToolkit) - The UWP Community Toolkit is a collection of helper functions, custom controls, and app services. It simplifies and demonstrates common developer tasks building UWP apps for Windows 10.
+* [ScintillaNET](https://github.com/jacobslusser/ScintillaNET) - Windows Forms control for the Scintilla text editor component (Scintilla is used by Notepad++)
 
 ## HTML and CSS
 


### PR DESCRIPTION
GUI/ScintillaNET - [github](https://github.com/jacobslusser/ScintillaNET)

Windows Forms control for the Scintilla text editor component. Scintilla is used by Notepad++.
Can also be used with WPF using the WindowsFormsHost.

- Super-fast multiline text editor component
- Supports syntax highilghting (coloring of code)
- Supports multiple margins / line numbers / breakpoint indicators
- Supports highlighting of arbitrary text in the document
- Supports code completion (IntelliSense drop downs)