### PR TITLE
Adding .NET Core in Action to Books section

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ Thanks to all [contributors](https://github.com/quozd/awesome-dotnet/graphs/cont
 ## Books
 
 * [Functional Programming in C#](https://www.manning.com/books/functional-programming-in-c-sharp) - teaches how to best leverage the functional features of the C# language. **[$]**
+* [.NET Core in Action](https://manning.com/books/dotnet-core-in-action) - teaches how to write applications and libraries with .NET Core. **[$]**
 
 ## Build Automation
 


### PR DESCRIPTION
Please consider including my book, .NET Core in Action, into your Books section. The first chapter is free. Although I'm not sure if waiting 1 year applies to books (or .NET Core).

