### PR TITLE
Update MVC.Template to the new version

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Thanks to all [contributors](https://github.com/quozd/awesome-dotnet/graphs/cont
 ## Application Templates
 
 * [ASP.NET Core Starter Kit](https://github.com/kriasoft/aspnet-starter-kit) - backend: .NET Core, EF Core, C#; frontend: Babel, Webpack, React, CSS Modules
-* [MVC.Template](https://github.com/NonFactors/MVC5.Template) - ASP.NET MVC 5 project starter template
+* [MVC.Template](https://github.com/NonFactors/MVC6.Template) - ASP.NET Core MVC project starter template.
 * [ProjectScaffold](https://github.com/fsprojects/ProjectScaffold) - A prototypical .NET solution recommended by the F# Foundation---includes file system setup, Paket for dependencies and FAKE for build/test automation. By default, build process also compiles documentation and generates NuGet packages.
 * [Serene](https://github.com/volkanceylan/Serenity) - Serenity is an ASP.NET MVC application platform designed to simplify and shorten development of data-centric business applications with a service based architecture. Serene is a starter template to build Serenity applications.
 * [Side-Waffle](https://github.com/LigerShark/side-waffle) - Large collection of useful templates for Web and Desktop development.


### PR DESCRIPTION
[MVC5 project](https://github.com/NonFactors/MVC5.Template) [->]() [ASP.NET core MVC project](https://github.com/NonFactors/MVC6.Template)

Updated MVC.Template reference to it's future home.
As I finished porting MVC5 template to ASP.NET core MVC.
And it will be the next supported version as the support for MVC5 will fade over the years.
