### PR TITLE
Add Loupe to Logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -488,6 +488,7 @@ Thanks to all [contributors](https://github.com/quozd/awesome-dotnet/graphs/cont
 * [Semantic Logging Application Block (SLAB)](http://slab.codeplex.com/) - Extends the inbuilt features of System.Diagnostics.Tracing namespace (EventSource class) to log to several sinks including Azure Tables, Databases, files (JSON, XML, text). Supports in-process and out-of-process logging through ETW, and Rx for real-time filtering/aggregating of events.
 * [Foundatio](https://github.com/exceptionless/Foundatio#logging) - A fluent logging api that can be used to log messages throughout your application. 
 * [Exceptionless](https://github.com/exceptionless/Exceptionless.Net) - Exceptionless .NET Client
+* [Loupe](https://onloupe.com) - Centralized .NET logging and monitoring.
 
 ## Machine Learning and Data Science
 * [Infer.NET](http://research.microsoft.com/en-us/um/cambridge/projects/infernet/default.aspx) - A framework for running Bayesian inference in graphical models. It can also be used for probabilistic programming. **[[Proprietary](http://research.microsoft.com/en-us/um/cambridge/projects/infernet/docs/Frequently%20Asked%20Questions.aspx)]** **[Free]** **[Research]**

--- a/README.md
+++ b/README.md
@@ -488,7 +488,7 @@ Thanks to all [contributors](https://github.com/quozd/awesome-dotnet/graphs/cont
 * [Semantic Logging Application Block (SLAB)](http://slab.codeplex.com/) - Extends the inbuilt features of System.Diagnostics.Tracing namespace (EventSource class) to log to several sinks including Azure Tables, Databases, files (JSON, XML, text). Supports in-process and out-of-process logging through ETW, and Rx for real-time filtering/aggregating of events.
 * [Foundatio](https://github.com/exceptionless/Foundatio#logging) - A fluent logging api that can be used to log messages throughout your application. 
 * [Exceptionless](https://github.com/exceptionless/Exceptionless.Net) - Exceptionless .NET Client
-* [Loupe](https://onloupe.com) - Centralized .NET logging and monitoring.
+* [Loupe](https://onloupe.com) - Centralized .NET logging and monitoring. **[Proprietary]** **[Free Tier]**
 
 ## Machine Learning and Data Science
 * [Infer.NET](http://research.microsoft.com/en-us/um/cambridge/projects/infernet/default.aspx) - A framework for running Bayesian inference in graphical models. It can also be used for probabilistic programming. **[[Proprietary](http://research.microsoft.com/en-us/um/cambridge/projects/infernet/docs/Frequently%20Asked%20Questions.aspx)]** **[Free]** **[Research]**


### PR DESCRIPTION
Logging/Loupe - [https://onloupe.com](https://onloupe.com)

Loupe captures errors in .NET software, identifies which errors are causing the greatest impact, and helps pinpoint root causes minimal effort. Available as cloud-hosted and self-hosted. Free .NET log viewer also available. **[$]**

**Publicly available community forum or other place for discussions and support?**
Yes: [Loupe Support Forum](http://support.onloupe.com/support/discussions)

**At least 1 year on the market**
Yes, since 2009.

**Free trial or preview?**
Free trial, [demo](https://onloupe.com/benefits/demo/), and [free desktop .NET log viewer](https://onloupe.com/local-logging/free-net-log-viewer) available.