### PR TITLE
Added language-ext and Functional programming

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Thanks to all [contributors](https://github.com/quozd/awesome-dotnet/graphs/cont
   * [E-Commerce and Payments](#e-commerce-and-payments)
   * [Environment Management](#environment-management)
   * [ETL](#etl)
+  * [Functional programming](#functional-programming)
   * [Game](#game)
   * [GIS](#gis)
   * [Git Tools](#git-tools)
@@ -342,6 +343,10 @@ Thanks to all [contributors](https://github.com/quozd/awesome-dotnet/graphs/cont
 ## ETL
 
 * [Reactive ETL](https://reactiveetl.codeplex.com/) - Reactive ETL is a rewrite of Rhino ETL using the reactive extensions for .NET
+
+## Functional programming
+
+* [language-ext](https://github.com/louthy/language-ext) - This library uses and abuses the features of C# 6+ to provide a functional 'Base class library', that, if you squint, can look like extensions to the language itself. It also includes an 'Erlang like' process system (actors) that can optionally persist messages and state to Redis (note you can use it without Redis for in-app messaging). The process system additionally supports Rx streams of messages and state allowing for a complete system of reactive events and message dispatch.
 
 ## Game
 


### PR DESCRIPTION
Functional programming/language-ext - [https://github.com/louthy/language-ext](https://github.com/louthy/language-ext)

Package of the week on Microsoft's .NET Blog: https://blogs.msdn.microsoft.com/dotnet/2016/09/20/the-week-in-net-on-net-with-steeltoe-c-functional-extensions-firewatch/

This library uses and abuses the features of C# 6 to provide a functional 'Base class library', that, if you squint, can look like extensions to the language itself. It also includes an 'Erlang like' process system (actors) that can optionally persist messages and state to Redis (note you can use it without Redis for in-app messaging). The process system additionally supports Rx streams of messages and state allowing for a complete system of reactive events and message dispatch.

Added language-ext and Functional programming section.  I have added the __Functional programming__ section because the last time I submitted this you claimed the API section was the wrong place, and to put it in Misc.  Misc is a really poor choice for an area that is growing massively in the .NET community, and is the entire direction that the C# language designers are taking.