### PR TITLE
Add OctoLinker browser extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -755,6 +755,7 @@ metadata in media files, including video, audio, and photo formats
 * [CatLight](https://catlight.io) - Build status notifications for TFS/Jenkins/Travis/Appveyor. Cross-platform desktop app based on .Net Core and Electron. **[Free][Proprietary]**
 * [Netling](https://github.com/hallatore/Netling) - A load tester client for easy web testing. It is extremely fast while using little CPU or memory.
 * [Visual Studio Uninstaller](https://github.com/Microsoft/VisualStudioUninstaller) - Uninstall and clean up all components of Visual Studio.
+* [OctoLinker](https://github.com/OctoLinker/browser-extension) - Navigate through `projects.json` files efficiently with the OctoLinker browser extension for GitHub.
 
 ## Trading
 


### PR DESCRIPTION
Tools/OctoLinker - [github.com/OctoLinker/browser-extension](https://github.com/OctoLinker/browser-extension)

Navigate through projects on GitHub.com efficiently with the OctoLinker browser extension.

Most projects consist of many files and third party dependencies. Files are referencing other files and / or dependencies by language specific statements like include or require. Dependencies are most likely declared in a file called manifest e.g. `package.json`, `project.json` or `Gemfile`. The OctoLinker browser extension makes these references clickable. No more copy and search.
## Demo

![dotnet](https://cloud.githubusercontent.com/assets/1393946/19506782/96134448-95ce-11e6-8cd7-3e608320a05a.gif)
