### PR TITLE
Add ReadLine

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ Thanks to all [contributors](https://github.com/quozd/awesome-dotnet/graphs/cont
 * [Colorful.Console](https://github.com/tomakita/Colorful.Console) - Colorful console output.
 * [EntryPoint](https://github.com/Nick-Lucas/EntryPoint) - Composable CLI Argument Parser for .Net Core & .Net Framework 4.5+.
 * [clipr](https://github.com/nemec/clipr) - A CLI library inspired by Python's argparse that transforms a command line into a strongly-typed object. It supports custom argument types, automated (and localized) help generation, and a variety of ways to store parsed arguments.
+* [ReadLine](https://github.com/tsolarin/readline) - A GNU-Readline like library for .NET/.NET Core.
 
 ## CLR
 


### PR DESCRIPTION
CLI/ReadLine - [https://github.com/tsolarin/readline](https://github.com/tsolarin/readline)

PROJECT_DESCRIPTION

ReadLine is a GNU Readline like library built in pure C#. It can serve as a drop in replacement for the inbuilt Console.ReadLine() and brings along with it some of the terminal goodness you get from unix shells, like command history navigation and tab auto completion.

It is cross platform and runs anywhere .NET is supported, targeting netstandard1.3 means that it can be used with .NET Core as well as the full .NET Framework.
