### PR TITLE
add GeoJSON4EntityFramework

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,6 +392,7 @@ Thanks to all [contributors](https://github.com/quozd/awesome-dotnet/graphs/cont
  * [NetTopologySuite](https://github.com/NetTopologySuite/NetTopologySuite/)  A .NET GIS solution that is fast and reliable for the .NET platform
  * [SharpMap](https://sharpmap.codeplex.com/) An easy-to-use mapping library for use in web and desktop applications
  * [OsmSharp](http://www.osmsharp.com/) - C# library to work with OpenStreetMap (OSM) data. Provides reading, writing and route-planning for OSM data.
+ * [GeoJSON4EntityFramework](https://github.com/alatas/GeoJSON4EntityFramework) - A library to create GeoJSON from Entity Framework Spatial Data or Well-Known Text (WKT) inputs.
 
 ## Git Tools
 


### PR DESCRIPTION
GIS/GeoJSON4EntityFramework - [Github](https://github.com/alatas/GeoJSON4EntityFramework)

GeoJSON for EntityFramework is a .net library that allows you to create GeoJSON output from EntityFramework Spatial Data or WKT inputs. In other words, It serializes different type of geometry objects to GeoJSON. It's not limited to only EF entities but It can serialize WKT inputs as well.

- Supports Entity Framework v6 (System.Data.Entity.Spatial namespace) and Entity Framework v5 (System.Data.Spatial namespace) objects
- Supports Well-known Text inputs
- Supports DbGeometry (planar) and DbGeography (geodetic "round earth") objects
- Supports all types of features defined in geojson specs (RFC 7946)
- Supports boundingbox property defined in geojson specs (RFC 7946)
- Supports geometry transform
