### PR TITLE
Add Expecto to testing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -787,6 +787,7 @@ metadata in media files, including video, audio, and photo formats
 * [xBehave.net](https://github.com/xbehave/xbehave.net) - A BDD/TDD framework based on xUnit.net and inspired by Gherkin. http://xbehave.github.io
 * [xUnit](https://github.com/xunit/xunit) - xUnit.net is a free, open source, community-focused unit testing tool for the .NET Framework
 * [Canopy](https://github.com/lefthandedgoat/canopy) - Canopy is a free, open source F# web automation and testing framework 
+* [Expecto](https://github.com/haf/expecto) - A smooth testing framework for F# with tests as values. Unit testing, property based testing, performance testing and stress testing.
 
 ## Tools
 


### PR DESCRIPTION
Testing/Expecto - [Expecto](https://github.com/haf/expecto)

Expecto is a smooth testing framework for F#, with APIs made for humans, giving strong testing methodologies to everyone. Unit testing, property based testing, performance testing and stress testing.

With Expecto you write tests as values. Tests can be composed, reduced, filtered, repeated and passed as values, because they are values. This gives the programmer a lot of leverage when writing tests.

Expecto comes with batteries included, but it's still open for extension due to its compositional model.