### PR TITLE
Added LibSass Host to HTML and CSS

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,6 +449,7 @@ Thanks to all [contributors](https://github.com/quozd/awesome-dotnet/graphs/cont
 * [ExCSS](https://github.com/TylerBrinks/ExCSS) - CSS3 parser Library for C#
 * [FluentBootstrap](http://fluentbootstrap.com) - Makes the Bootstrap CSS framework easier to use from ASP.NET MVC or WebPages.
 * [HtmlAgilityPack](http://htmlagilitypack.codeplex.com/) - an agile HTML parser that builds a read/write DOM and supports plain XPATH or XSLT
+* [LibSass Host](https://github.com/Taritsyn/LibSassHost) - .NET wrapper around the [libSass](http://sass-lang.com/libsass) library with the ability to support a virtual file system
 
 ## HTTP
 


### PR DESCRIPTION
HTML and CSS/LibSass Host - https://github.com/Taritsyn/LibSassHost

.NET wrapper around the [libSass](http://sass-lang.com/libsass) library with the ability to support a virtual file system.