### PR TITLE
Add C# in Depth to books list

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ Thanks to all [contributors](https://github.com/quozd/awesome-dotnet/graphs/cont
 ## Books
 
 * [.NET Core in Action](https://www.manning.com/books/dotnet-core-in-action) - teaches how to write applications and libraries with .NET Core. **[$]**
+* C# in Depth - [3rd edition](https://www.manning.com/books/c-sharp-in-depth-third-edition), [4th edition (early access)](https://www.manning.com/books/c-sharp-in-depth-fourth-edition) - deep dive into the details of the C# language. **[$]**
 * [CLR via C#](https://www.microsoftpressstore.com/store/clr-via-c-sharp-9780735667457) - Dig deep and master the intricacies of the common language runtime, C#, and .NET development. **[$]**
 * [Functional Programming in C#](https://www.manning.com/books/functional-programming-in-c-sharp) - teaches how to best leverage the functional features of the C# language. **[$]**
 * [Microservices in .NET Core](https://www.manning.com/books/microservices-in-net-core) - shows you how to build maintainable, secure and operations-friendly microservices using Nancy and .NET Core. **[$]**


### PR DESCRIPTION
Books/C# in Depth- [3rd edition](https://www.manning.com/books/c-sharp-in-depth-third-edition) and [4th edition](https://www.manning.com/books/c-sharp-in-depth-fourth-edition)

Deep dive into the details of the C# language.

If you'd prefer to either have only one link (which version?) or links as separate entries, let me know and I'll create a replacement PR.