### PR TITLE
Add NsDepCop

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ Thanks to all [contributors](https://github.com/quozd/awesome-dotnet/graphs/cont
 * [AspNet.Metrics](https://github.com/alhardy/aspnet-metrics) - Capturing CLR, application-level web request metrics. Middleware and extensions using Metrics-Net
 * [BenchmarkDotNet](https://github.com/dotnet/BenchmarkDotNet) - Powerful .NET library for benchmarking.
 * [Codinion](http://www.codinion.com/) - Enhanced syntax highlighting for C# and some other "Visual" features.
+* [NsDepCop](https://github.com/realvizu/NsDepCop) - Static code analysis tool to enforce namespace dependency rules in C# projects.
 
 ## Code Snippets
 


### PR DESCRIPTION
Code Analysis and Metrics/NsDepCop - [https://github.com/realvizu/NsDepCop](https://github.com/realvizu/NsDepCop)

Static code analysis tool to enforce namespace dependency rules in C# projects.
