### PR TITLE
Add WinFsp

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Thanks to all [contributors](https://github.com/quozd/awesome-dotnet/graphs/cont
   * [ETL](#etl)
   * [Exceptions](#exceptions)
   * [Extensions librairies](#extensions)
+  * [File Systems](#file-systems)
   * [Functional programming](#functional-programming)
   * [Game](#game)
   * [GIS](#gis)
@@ -384,6 +385,10 @@ Thanks to all [contributors](https://github.com/quozd/awesome-dotnet/graphs/cont
 
 ## Extensions
 * [Z.ExtensionMethods](https://github.com/zzzprojects/Z.ExtensionMethods) - Over a 1000 useful extension methods
+
+## File Systems
+
+* [WinFsp](https://github.com/billziss-gh/winfsp) - Windows File System Proxy - FUSE for Windows. A set of software components for Windows computers that allows the creation of user mode file systems that fully integrate with the OS. Includes .NET layer.
 
 ## Functional programming
 


### PR DESCRIPTION
File Systems/WinFsp - [https://github.com/billziss-gh/winfsp](https://github.com/billziss-gh/winfsp)

Windows File System Proxy - FUSE for Windows. A set of software components for Windows computers that allows the creation of user mode file systems that fully integrate with the OS. Includes .NET layer.