### PR TITLE
add SharpNetSH

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ To the extent possible under law, [Vitali Fokin](https://github.com/quozd) has w
 * [EntryPoint](https://github.com/Nick-Lucas/EntryPoint) - Composable CLI Argument Parser for .Net Core & .Net Framework 4.5+.
 * [clipr](https://github.com/nemec/clipr) - A CLI library inspired by Python's argparse that transforms a command line into a strongly-typed object. It supports custom argument types, automated (and localized) help generation, and a variety of ways to store parsed arguments.
 * [ReadLine](https://github.com/tonerdo/readline) - A GNU-Readline like library for .NET/.NET Core.
+* [SharpNetSH](https://github.com/rpetz/SharpNetSH) - A simple netsh library for C#.
 
 ## CLR
 


### PR DESCRIPTION
CLI/SharpNetSH - [https://github.com/rpetz/SharpNetSH](SharpNetSH)

A simple netsh library for C#.

<!--
  Please, fill in this PR template. It will help maintainers to do the review.
  Also, please read our [Contribution guidelines](CONTRIBUTING.md). 
  Please, create one pull request per link.
-->
