### PR TITLE
Fix link to other lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,10 +112,8 @@ To the extent possible under law, [Vitali Fokin](https://github.com/quozd) has w
   * [Windows Services](#windows-services)
   * [WPF](#wpf)
   * [Other Lists](#other-lists)
-
-
+* [Other Lists](#other-lists)
 * [Resources](#resources)
-* [Other Awesome Lists](#other-awesome-lists)
 
 ## Algorithms and Data structures
 


### PR DESCRIPTION
The anchor link was broken since the other lists section had been renamed.
