### PR TITLE
Added RegexToolbox.CSharp

### DIFF
--- a/README.md
+++ b/README.md
@@ -626,6 +626,7 @@ metadata in media files, including video, audio, and photo formats
 * [LINQPad](http://www.linqpad.net) - a C#/VB/F# scratchpad that instantly executes any expression, statement block or program with rich output formatting and a wealth of features. Also lets you interactively query databases in LINQ. [$]
 * [Polly](https://github.com/App-vNext/Polly) - Express transient-exception-handling and resilience policies such as Retry, Wait-and-Retry, Circuit Breaker, and Bulkhead Isolation in a fluent manner. Fully thread-safe and full async support.  (4.0 / 4.5 / .Net Core / .Net Standard / Xamarin).  
 * [Rant](https://github.com/TheBerkin/Rant) - The Rant Procedural Text Generation DSL http://berkin.me/rant/
+* [RegexToolbox.CSharp](https://github.com/markwhitaker/RegexToolbox.CSharp) - Regular expression tools for C# developers
 * [ScriptCS](https://github.com/scriptcs/scriptcs) - Write C# apps with a text editor, nuget and the power of Roslyn!
 * [Shielded](https://github.com/jbakic/Shielded) - Software Transactional Memory (STM) implementation for .NET
 * [MSBuild ILMerge task](https://ilmergemsbuild.codeplex.com/) - MSBuild ILMerge task is a NuGet package allows you to use the famous ILMerge utility in automated builds and/or Visual Studio projects.


### PR DESCRIPTION
Misc/RegexToolbox.CSharp - [https://github.com/markwhitaker/RegexToolbox.CSharp](https://github.com/markwhitaker/RegexToolbox.CSharp)

Regular expression tools for C# developers. Primarily `RegexBuilder`, a class for building regular expressions in a more human-readable way using a fluent API.