### PR TITLE
Move JsonFlatFileDataStore from ORM to Database

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,7 @@ To the extent possible under law, [Vitali Fokin](https://github.com/quozd) has w
 * [Streamstone](https://github.com/yevhen/Streamstone) - Event store for Azure Table Storage
 * [Ignite](https://github.com/apache/ignite) - Distributed in-memory platform: document database with SQL and LINQ support; distributed computations; distributed services and events.
 * [Yessql](https://github.com/sebastienros/yessql) - A .NET document database working on any RDBMS
+* [JsonFlatFileDataStore](https://github.com/ttu/json-flatfile-datastore) - Simple JSON flat file data store with support for typed and dynamic data
 
 ## Database Drivers
 
@@ -690,7 +691,6 @@ metadata in media files, including video, audio, and photo formats
 * [LLBLGen Pro](https://www.llblgen.com) - Entity Modeling solution for Entity Framework, NHibernate, Linq to SQL and its own ORM framework: LLBLGen Pro Runtime Framework. **[$][Free Lite version]**
 * [Insight.Database](https://github.com/jonwagner/Insight.Database) - Insight.Database is a fast, lightweight, micro-orm for .NET
 * [DbExtensions](http://maxtoroq.github.io/DbExtensions/) - Data-access framework with a strong focus on query composition, granularity and code aesthetics.
-* [JsonFlatFileDataStore](https://github.com/ttu/json-flatfile-datastore) - Simple JSON flat file data store with support for typed and dynamic data.
 
 ## Package Management
 


### PR DESCRIPTION
JsonFlatFileDataStore - [https://github.com/ttu/json-flatfile-datastore](https://github.com/ttu/json-flatfile-datastore)

Simple JSON flat file data store. Has a support for typed and dynamic data. Great help for prototyping etc. as data is stored to easily editable JSON file. 

Also available as a NuGet package:
https://www.nuget.org/packages/JsonFlatFileDataStore/

I misplaced JsonFlatFileDataStore to wrong category. Correct category is Database.
