### PR TITLE
Add WKHTML

### DIFF
--- a/README.md
+++ b/README.md
@@ -701,6 +701,7 @@ metadata in media files, including video, audio, and photo formats
 ## PDF
 
 * [ITextSharp](https://github.com/itext/itextsharp) - iText is a PDF library that allows you to CREATE, ADAPT, INSPECT and MAINTAIN documents in the Portable Document Format (PDF)**[$]****[Free for OSS]**
+* [WKHTML] (https://wkhtmltopdf.org/) - WKHTML is a open source command line tools to render HTML into PDF and various image formats using the Qt WebKit rendering engine
 
 ## Profiler
 

--- a/README.md
+++ b/README.md
@@ -701,7 +701,7 @@ metadata in media files, including video, audio, and photo formats
 ## PDF
 
 * [ITextSharp](https://github.com/itext/itextsharp) - iText is a PDF library that allows you to CREATE, ADAPT, INSPECT and MAINTAIN documents in the Portable Document Format (PDF)**[$]****[Free for OSS]**
-* [WKHTML] (https://wkhtmltopdf.org/) - WKHTML is a open source command line tools to render HTML into PDF and various image formats using the Qt WebKit rendering engine
+* [WKHTML](https://wkhtmltopdf.org/) - WKHTML is a open source command line tools to render HTML into PDF and various image formats using the Qt WebKit rendering engine
 
 ## Profiler
 


### PR DESCRIPTION
PDF/WKHTML - https://wkhtmltopdf.org/

PROJECT_DESCRIPTION

What is it?
wkhtmltopdf and wkhtmltoimage are open source (LGPLv3) command line tools to render HTML into PDF and various image formats using the Qt WebKit rendering engine. These run entirely "headless" and do not require a display or display service.

There is also a C library, if you're into that kind of thing.

How do I use it?
Download a precompiled binary or build from source
Create your HTML document that you want to turn into a PDF (or image)
Run your HTML document through the tool.
For example, if I really like the treatment Google has done to their logo today and want to capture it forever as a PDF:

wkhtmltopdf http://google.com google.pdf

Additional options
That's great, I've always wanted to turn Google's homepage into a PDF, but I want a table of contents as well.

There are plenty of command line options. Check out the auto-generated wkhtmltopdf manual.
