### PR TITLE
Update ASP.NET Identity Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ To the extent possible under law, [Vitali Fokin](https://github.com/quozd) has w
 
 ## Authentication and Authorization
 
-* [ASP.NET Identity](https://aspnetidentity.codeplex.com/) - New membership system for ASP.NET applications
+* [ASP.NET Identity](https://github.com/aspnet/Identity/) - New membership system for ASP.NET applications
 * [DotNetOpenAuth](https://github.com/DotNetOpenAuth/DotNetOpenAuth) - A C# implementation of the OpenID, OAuth and InfoCard protocols
 * [Logibit Hawk](https://github.com/logibit/logibit.hawk/) - A F# [Hawk](https://github.com/hueniverse/hawk#usage-example) authentication library
 * [IdentityModel](https://github.com/IdentityModel) - Helper library for identity & access control in .NET 4.5 and MVC4/Web API.


### PR DESCRIPTION
Link for ASP.NET Identity was pointing to old CodePlex, updated to point to current GitHub repo.

CATEGORY/PROJECT_NAME - Authentication and Authorization/ASP.NET Identity

PROJECT_DESCRIPTION

No changes to description, just updated link from CodePlex to GitHub repo.
