### PR TITLE
Add LegacyWrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -524,6 +524,7 @@ To the extent possible under law, [Vitali Fokin](https://github.com/quozd) has w
 * [Sharpen](https://github.com/mono/sharpen) - Sharpen is an Eclipse plugin created by db4o that allows you to convert your Java project into C#
 * [CXXI](https://github.com/mono/cxxi) - C++ interop framework
 * [pythonnet](https://github.com/pythonnet/pythonnet) - Python and .NET interop framework
+* [LegacyWrapper](https://github.com/CodefoundryDE/LegacyWrapper) - LegacyWrapper uses a wrapper process to call DLLs from a process of the opposing architecture (X86 or AMD64).
 
 ## IoC
 


### PR DESCRIPTION
https://github.com/CodefoundryDE/LegacyWrapper

LegacyWrapper uses a wrapper process to call dlls from a process of the opposing architecture (X86 or AMD64).

Since you can't load a dll of another architecture directly, the wrapper utilizes a named pipe to abstract the call. You won't notice this though, because all the magic is hidden behind a single static method.

CATEGORY/PROJECT_NAME - [PROJECT_LINK](PROJECT_LINK)

PROJECT_DESCRIPTION

<!--
  Please, fill in this PR template. It will help maintainers to do the review.
  Also, please read our [Contribution guidelines](CONTRIBUTING.md). 
  Please, create one pull request per link.
-->
