### PR TITLE
added utf8json library

### DIFF
--- a/README.md
+++ b/README.md
@@ -798,6 +798,7 @@ metadata in media files, including video, audio, and photo formats
 * [FileHelpers](https://github.com/MarcosMeli/FileHelpers) - free and easy to use .NET library to import or export data from fixed length or delimited records in files, strings or streams.
 * [FsPickler](https://github.com/mbraceproject/FsPickler) - A fast multi-format message serializer for .NET
 * [Migrant](https://github.com/antmicro/Migrant) - Fast and flexible serialization framework usable on undecorated classes.
+* [Utf8Json](https://github.com/neuecc/Utf8Json) - Fast and Zero Allocation JSON Serializer for C#(.NET, .NET Core, Unity and Xamarin), this serializer write/read directly to UTF8 binary so boostup performance.
 
 ## SMS and Phone calls
 


### PR DESCRIPTION
Serialization/Utf8Json - [Utf8Json](https://github.com/neuecc/Utf8Json)

> Definitely Fastest and Zero Allocation JSON Serializer for C#(.NET, .NET Core, Unity and Xamarin), this serializer write/read directly to UTF8 binary so boostup performance.

This is a quite new and young (on github but I assume author was working for longer time behind the doors) serialization library but it has comprehensive tests and is quite well tested. [Benchmarks](https://gist.github.com/Tornhoof/00c5b5e73d46ea4710a5a4b3c714ba50) show that it at least as fast as Jil but has much less allocations. It's the most memory efficient library and it can even be compared to protobuf
