### PR TITLE
Add YoutubeExplode

### DIFF
--- a/README.md
+++ b/README.md
@@ -656,6 +656,7 @@ metadata in media files, including video, audio, and photo formats
 * [HidLibrary](https://github.com/mikeobrien/HidLibrary) - This library enables you to enumerate and communicate with Hid compatible USB devices in .NET.
 * [SystemWrapper](https://github.com/jozefizso/SystemWrapper) - SystemWrapper is .NET library for easier testing of system APIs.
 * [Sprache](https://github.com/sprache/Sprache) - A simple, lightweight library for constructing parsers directly in C# code
+* [YoutubeExplode](https://github.com/Tyrrrz/YoutubeExplode) - Ultimate library for extracting metadata and downloading Youtube videos and playlists.
 
 ## MVVM
 


### PR DESCRIPTION
MISC/YoutubeExplode - https://github.com/Tyrrrz/YoutubeExplode

YoutubeExplode is a library that provides an interface to query metadata of Youtube videos, playlists and channels, as well as to resolve and download video streams and closed caption tracks. Behind a layer of abstraction, the library parses raw page content and uses reverse-engineered AJAX requests to retrieve information. As it doesn't use the official API, there's also no need for an API key and there are no usage quotas.
