### PR TITLE
Add docopt in CLI section

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ To the extent possible under law, [Vitali Fokin](https://github.com/quozd) has w
 * [clipr](https://github.com/nemec/clipr) - A CLI library inspired by Python's argparse that transforms a command line into a strongly-typed object. It supports custom argument types, automated (and localized) help generation, and a variety of ways to store parsed arguments.
 * [ReadLine](https://github.com/tonerdo/readline) - A GNU-Readline like library for .NET/.NET Core.
 * [SharpNetSH](https://github.com/rpetz/SharpNetSH) - A simple netsh library for C#.
+* [Docopt](https://github.com/docopt/docopt.net) - Command-line interface description language that will make you smile.
 
 ## CLR
 


### PR DESCRIPTION
CLI/docopt- [docopt](https://github.com/docopt/docopt.net)

Isn't it awesome how CommandLineParser and PowerArgs generate help messages based on your code?!

Hell no! You know what's awesome? It's when the option parser is generated based on the beautiful help message that you write yourself! This way you don't need to write this stupid repeatable parser-code, and instead can write only the help message--the way you want it.

docopt.net helps you create most beautiful command-line interfaces easily:
