### PR TITLE
Added AutoDiff

### DIFF
--- a/README.md
+++ b/README.md
@@ -613,6 +613,7 @@ To the extent possible under law, [Vitali Fokin](https://github.com/quozd) has w
 * [Microsoft Automatic Graph Layout](https://github.com/Microsoft/automatic-graph-layout) - A set of tools for graph layout and viewing.
 * [UnitConversion](https://github.com/Stratajet/UnitConversion) - Expansible Unit Conversion Library for .NET Core and .NET Framework
 * [ALGLIB](http://www.alglib.net/) - ALGLIB is a cross-platform numerical analysis and data processing library. It supports several programming languages (C++, C#, Delphi) and several operating systems (Windows and POSIX, including Linux) **[Proprietary]** and **[Free Edition]**
+* [AutoDiff](https://github.com/alexshtf/autodiff) - AutoDiff is a library for quickly computing gradients of functions defined by expressions. Mainly useful in numerical optimization
 
 ## Media
 


### PR DESCRIPTION
Mathematics/AutoDiff - [https://github.com/alexshtf/autodiff](https://github.com/alexshtf/autodiff)

AutoDiff is a library for quickly computing gradients of functions defined by expressions. Mainly useful in numerical optimization.