### PR TITLE
Add posh-dotnet (PowerShell tab completion for the dotnet CLI)

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ To the extent possible under law, [Vitali Fokin](https://github.com/quozd) has w
 * [ReadLine](https://github.com/tonerdo/readline) - A GNU-Readline like library for .NET/.NET Core.
 * [SharpNetSH](https://github.com/rpetz/SharpNetSH) - A simple netsh library for C#.
 * [Docopt](https://github.com/docopt/docopt.net) - Command-line interface description language that will make you smile.
+* [posh-dotnet](https://github.com/bergmeister/posh-dotnet) - `PowerShell` tab completion for the [dotnet CLI](https://github.com/dotnet/cli).
 
 ## CLR
 

--- a/README.md
+++ b/README.md
@@ -222,7 +222,6 @@ To the extent possible under law, [Vitali Fokin](https://github.com/quozd) has w
 * [ReadLine](https://github.com/tonerdo/readline) - A GNU-Readline like library for .NET/.NET Core.
 * [SharpNetSH](https://github.com/rpetz/SharpNetSH) - A simple netsh library for C#.
 * [Docopt](https://github.com/docopt/docopt.net) - Command-line interface description language that will make you smile.
-* [posh-dotnet](https://github.com/bergmeister/posh-dotnet) - `PowerShell` tab completion for the [dotnet CLI](https://github.com/dotnet/cli).
 
 ## CLR
 
@@ -879,6 +878,7 @@ metadata in media files, including video, audio, and photo formats
 * [Papercut](https://github.com/ChangemakerStudios/Papercut) - Papercut is an open source (.NET based) test email viewer that runs locally with a built-in SMTP server designed to receive and notify of test email messages.
 * [Visual Studio Uninstaller](https://github.com/Microsoft/VisualStudioUninstaller) - Uninstall and clean up all components of Visual Studio.
 * [Fake JSON Server](https://github.com/ttu/dotnet-fake-json-server) - Fake REST API for prototyping or as a CRUD Back End. No need to define types, uses dynamic typing. Data is stored to a single JSON file. Has authentication, WebSocket notifications, async long running operations, random generation for errors/delays and experimental GraphQL support.
+* [posh-dotnet](https://github.com/bergmeister/posh-dotnet) - `PowerShell` tab completion for the [dotnet CLI](https://github.com/dotnet/cli)
 
 ## Trading
 


### PR DESCRIPTION
CLI/posh-dotnet - [posh-dotnet](https://github.com/bergmeister/posh-dotnet)

`PowerShell` tab completion for the [dotnet CLI](https://github.com/dotnet/cli).

This module enhances the tab completion of the dotnet cli 2.0 (which is disabled by default) and also provides support for the dotnet cli 1.0 (which had not tab completion at all)