### PR TITLE
Add ReduxSimple

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ To the extent possible under law, [Vitali Fokin](https://github.com/quozd) has w
   * [Serialization](#serialization)
   * [SMS and Phone Calls](#sms-and-phone-calls)
   * [State machines](#state-machines)
+  * [State Management](#state-management)
   * [Static Site Generators](#static-site-generators)
   * [Style Guide](#style-guide)
   * [Template Engine](#template-engine)
@@ -826,6 +827,10 @@ metadata in media files, including video, audio, and photo formats
 * [Automatonymous](https://github.com/MassTransit/Automatonymous) - A state machine library for .NET - allows you to write fluent style state machines
 * [Appccelerate - State Machine](http://www.appccelerate.com/statemachine.html) - A powerful state machine library - configured with a fluent API and synchrounous and asynchronous state transition support
 * [LiquidState](https://github.com/prasannavl/LiquidState) - Efficient asynchronous and synchronous state machines for .NET
+
+## State Management
+
+* [ReduxSimple](https://github.com/Odonno/ReduxSimple) - Simple Stupid Redux Store using Reactive Extensions
 
 ## Static Site Generators
 * [FsBlog](https://github.com/fsprojects/FsBlog/) - Blog aware, static site generation using F#


### PR DESCRIPTION
StateManagement/ReduxSimple - [https://github.com/Odonno/ReduxSimple](https://github.com/Odonno/ReduxSimple)

Simple Stupid Redux Store using Reactive Extensions

ReduxSimple is one of my library. It is a really small but powerful library to handle State Management, in a Redux-like style for JavaScript. It is built with ReactiveExtensions so developers have everything they need to get started and publish new Actions, Subscribe to Actions/State and deal with Side Effects.