### PR TITLE
Add Getty Images API SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -803,6 +803,7 @@ metadata in media files, including video, audio, and photo formats
 * [Azure PowerShell](https://github.com/Azure/azure-powershell) - A set of PowerShell cmdlets for developers and administrators to develop, deploy and manage Microsoft Azure applications
 * [Octokit.NET](https://github.com/octokit/octokit.net) - A GitHub API client library for .NET
 * [DropNet](https://github.com/DropNet/DropNet) - Client library for the Dropbox API
+* [Getty Images API SDK](https://github.com/gettyimages/gettyimages-api_dotnet) - SDK for the Getty Images and iStock APIs
 
 ## Search
 


### PR DESCRIPTION
SDK is open source and developers are able to get a test key to try out the API.

SDK/Getty Images API SDK - [https://github.com/gettyimages/gettyimages-api_dotnet](https://github.com/gettyimages/gettyimages-api_dotnet)

Client library for making calls against the Getty Images and iStock APIs. 
[Getty Images API Portal](https://developers.gettyimages.com)

<!--
  Please, fill in this PR template. It will help maintainers to do the review.
  Also, please read our [Contribution guidelines](CONTRIBUTING.md). 
  Please, create one pull request per link.
-->
