### PR TITLE
Add Mond scripting language

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,7 @@ To the extent possible under law, [Vitali Fokin](https://github.com/quozd) has w
 * [FunScript](http://funscript.info/) - F# to JavaScript compiler with jQuery etc. mappings through a TypeScript type provider.
 * [IronScheme](https://github.com/leppie/IronScheme) - R6RS Scheme compiler, runtime and many standard libraries
 * [JSIL](https://github.com/sq/JSIL) - CIL to JavaScript Compiler http://jsil.org/
+* [Mond](https://github.com/Rohansi/Mond) - A dynamically typed scripting language written in C# with a REPL, debugger, and simple embedding API.
 * [Mono-basic](https://github.com/mono/mono-basic) - Visual Basic Compiler and Runtime
 * [Nemerle](https://github.com/rsdn/nemerle) - Nemerle is a high-level statically-typed programming language for the .NET platform. It offers functional, object-oriented and imperative features. It has a simple C#-like syntax and a powerful meta-programming system. 
 * [Netjs](https://github.com/praeclarum/Netjs) - .NET to TypeScript and JavaScript compiler. Portable Class Libraries work great for this. You can even pass EXEs.


### PR DESCRIPTION
Compilers, Transpilers and Languages/Mond - [https://github.com/Rohansi/Mond](https://github.com/Rohansi/Mond)

A dynamically typed scripting language written in C# with a REPL, debugger, and simple embedding API.

---

Mond is a scripting language that was written in pure C# to avoid deployment headaches other libraries have because they depend on native code. It maintained compatibility with Mono and now targets .NET Standard for portability.

It supports debugging the scripts using the existing remote debugger package, has a simple way to bind C# classes, a REPL with syntax highlighting, language features inspired by F#, and a website to try it out online.