### PR TITLE
Add hybridizer in compiler section

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,7 @@ To the extent possible under law, [Vitali Fokin](https://github.com/quozd) has w
 * [ClojureCLR](https://github.com/clojure/clojure-clr) - A port of Clojure to the CLR, part of the Clojure project
 * [F#](https://github.com/fsharp/fsharp/) -  The F# compiler, core library and tools - a functional programming language for safer, faster, better code writing.
 * [FunScript](http://funscript.info/) - F# to JavaScript compiler with jQuery etc. mappings through a TypeScript type provider.
+* [Hybridizer](http://www.altimesh.com/hybridizer-essentials/) - CIL (C#, VB.Net, F#) to CUDA compiler. 
 * [IronScheme](https://github.com/leppie/IronScheme) - R6RS Scheme compiler, runtime and many standard libraries
 * [JSIL](https://github.com/sq/JSIL) - CIL to JavaScript Compiler http://jsil.org/
 * [Mond](https://github.com/Rohansi/Mond) - A dynamically typed scripting language written in C# with a REPL, debugger, and simple embedding API.

--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ To the extent possible under law, [Vitali Fokin](https://github.com/quozd) has w
 * [ClojureCLR](https://github.com/clojure/clojure-clr) - A port of Clojure to the CLR, part of the Clojure project
 * [F#](https://github.com/fsharp/fsharp/) -  The F# compiler, core library and tools - a functional programming language for safer, faster, better code writing.
 * [FunScript](http://funscript.info/) - F# to JavaScript compiler with jQuery etc. mappings through a TypeScript type provider.
-* [Hybridizer](http://www.altimesh.com/hybridizer-essentials/) - CIL (C#, VB.Net, F#) to CUDA compiler. 
+* [Hybridizer](http://www.altimesh.com/hybridizer-essentials/) - CIL (C#, VB.Net, F#) to CUDA compiler. **[$]**
 * [IronScheme](https://github.com/leppie/IronScheme) - R6RS Scheme compiler, runtime and many standard libraries
 * [JSIL](https://github.com/sq/JSIL) - CIL to JavaScript Compiler http://jsil.org/
 * [Mond](https://github.com/Rohansi/Mond) - A dynamically typed scripting language written in C# with a REPL, debugger, and simple embedding API.


### PR DESCRIPTION
Add hybridizer to compilers section

[Hybridizer](http://www.altimesh.com/hybridizer-essentials/) Hybridizer is a compiler targeting nvidia gpu from MSIL. Support of genetics and virtual functions, integrated with profilers and debuggers. **[$]**
Three months free trial. 
Free for academics, students and academics (not for OSS). Couldn't find a way to explain that. 

Issues tracking is on our github : https://github.com/altimesh/hybridizer-basic-samples/issues?q=is%3Aissue+is%3Aclosed

Documentation is [here](http://docs.altimesh.com/articles/intro.html) and [here](http://www.altimesh.com/get-started/)

Unfortunately our testing is internal, but we have a few thousands of them. 

Added a reference to Hybridizer, our proprietary CIL to CUDA compiler. 
