### PR TITLE
Adjust Cinchoo ETL library to other category

### DIFF
--- a/README.md
+++ b/README.md
@@ -629,6 +629,7 @@ To the extent possible under law, [Vitali Fokin](https://github.com/quozd) has w
 * [R Provider](http://bluemountaincapital.github.io/FSharpRProvider/) - Type provider that exposes R packages and functions in a type-safe way to F# callers
 * [F# Data](http://fsharp.github.io/FSharp.Data/) - F# type providers for accessing XML, JSON, CSV and HTML files (based on sample documents) and for accessing WorldBank data
 * [Spreads](https://github.com/Spreads/Spreads/) - Series and Panels for Real-time and Exploratory Analysis of Data Streams. Spreads library is optimized for performance and memory usage. It is several times faster than other open source projects.
+* [Cinchoo ETL](https://github.com/Cinchoo/ChoETL) - .NET library used to Read / Write CSV, Flat, Xml, JSON, Key-Value formatted files.
 
 ## Markdown Processors
 * [MarkdownSharp](https://code.google.com/archive/p/markdownsharp) - Open source C# implementation of Markdown processor, as featured on Stack Overflow.
@@ -849,6 +850,7 @@ metadata in media files, including video, audio, and photo formats
 
 * [Protobuf.NET](https://github.com/mgravell/protobuf-net) - Protocol buffers is the name of the binary serialization format used by Google for much of their data communications
 * [Json.NET](https://github.com/JamesNK/Newtonsoft.Json) - Popular high-performance JSON framework for .NET
+* [Cinchoo ETL](https://github.com/Cinchoo/ChoETL) - .NET library used to serialize CSV, Flat, Xml, JSON, Key-Value formatted files
 * [ServiceStack.Text](https://github.com/ServiceStack/ServiceStack.Text) - JSON, JSV and CSV Text Serializers used in servicestack.net
 * [Msgpack-Cli](https://github.com/msgpack/msgpack-cli) - MessagePack implementation for Common Language Infrastructure
 * [Jil](https://github.com/kevin-montrose/Jil) - Fast .NET JSON serializer, built on Sigil (used by StackOverflow)


### PR DESCRIPTION
Added Cinchoo ETL to 'Serialization' and 'Machine Learning and Data Science'
