### PR TITLE
Add CoreRPC

### DIFF
--- a/README.md
+++ b/README.md
@@ -526,6 +526,7 @@ To the extent possible under law, [Vitali Fokin](https://github.com/quozd) has w
 * [RestEase](https://github.com/canton7/RestEase) - Easy-to-use typesafe REST API client library, which is simple and customisable. Heavily inspired by Refit
 * [RestLess](https://github.com/letsar/RestLess) - The automatic type-safe-reflectionless REST API client library for .Net Standard.
 * [HttpClientGoodies](https://github.com/jeffijoe/httpclientgoodies.net) - utilities for working with `HttpClient`
+* [CoreRPC](https://github.com/kekekeks/CoreRPC) - Extensible library for WCF-like RPC targeting netstandard1.3. Compatible with .NET, Mono and .NET Core.
 
 ## IDE
 


### PR DESCRIPTION
HTTP/CoreRPC - [https://github.com/kekekeks/CoreRPC](https://github.com/kekekeks/CoreRPC)

> Extensible library for WCF-like RPC targeting netstandard1.3 (compatible with .NET, Mono and .NET Core). Supports both HTTP and TCP modes. TCP transport supports connection pooling and multiplexing requests within one connection, infrastructure itself allows multiple "services" to be hosted inside one host. You may define your own handler factory or "routing" mechanism. Serializer (JSON.NET is used by default) is also easy to replace. 

I think adding this super-simple RPC communication library is really worth it.