### PR TITLE
Fix a typo in .NET Standard

### DIFF
--- a/README.md
+++ b/README.md
@@ -886,7 +886,7 @@ metadata in media files, including video, audio, and photo formats
 ## Template Engine
 
 * [RazorEngine](https://github.com/Antaris/RazorEngine) - Open source templating engine based on Microsoft's Razor parsing engine
-* [RazorLight](https://github.com/toddams/RazorLight) - Open source template engine based on Microsoft's Razor parsing engine supporting .NET Standart 2.0
+* [RazorLight](https://github.com/toddams/RazorLight) - Open source template engine based on Microsoft's Razor parsing engine supporting .NET Standard 2.0
 * [Nustache](https://github.com/jdiamond/Nustache) - Open source library for logic-less templates
 * [Stubble](https://github.com/stubbleorg/stubble) - Trimmed down {{mustache}} templates in .NET. Successor of Nustache.
 * [DotLiquid](https://github.com/dotliquid/dotliquid) - C# port of the Ruby Liquid templating language


### PR DESCRIPTION
Fixed typo in RazorLight description. 
