### PR TITLE
add RunInfoBuilder (CLI)

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ To the extent possible under law, [Vitali Fokin](https://github.com/quozd) has w
 * [Gui.cs](https://github.com/migueldeicaza/gui.cs) - Terminal UI toolkit for .NET.
 * [Power Args](https://github.com/adamabdelhamed/PowerArgs) - PowerArgs converts command-line arguments into .NET objects that are easy to program against. It also provides a ton of optional capabilities such as argument validation, auto generated usage, tab completion, and plenty of extensibility
 * [ReadLine](https://github.com/tonerdo/readline) - A GNU-Readline like library for .NET/.NET Core.
+* [RunInfoBuilder](https://github.com/rushfive/RunInfoBuilder) - A unique command line parser, utilizing object trees for commands.
 * [SharpNetSH](https://github.com/rpetz/SharpNetSH) - A simple netsh library for C#.
 
 ## CLR


### PR DESCRIPTION
CLI/RunInfoBuilder - [https://github.com/rushfive/RunInfoBuilder](https://github.com/rushfive/RunInfoBuilder)

A command line parser that utilizer object trees for command configurations. Instead of using attributes to tell the parser how to handle program arguments, you instead configure an object that represents the command. This allows for greater flexibility to handle cases such as specifying custom callback functions, etc.

Everything is fully documented in the projects README.

Thanks for your time :)