### PR TITLE
added Stryker.NET as mutation testing framework to the testing category.

### DIFF
--- a/README.md
+++ b/README.md
@@ -917,6 +917,7 @@ metadata in media files, including video, audio, and photo formats
 * [Rhino Mocks](https://github.com/ayende/rhino-mocks) - Dynamic Mocking Framework for .NET
 * [Shouldly](https://github.com/shouldly/shouldly) - Shouldly is an assertion framework which focuses on giving great error messages when the assertion fails while being simple and terse.
 * [SpecFlow](https://github.com/techtalk/SpecFlow/) - Binding business requirements to .Net code
+* [Stryker.NET](https://github.com/stryker-mutator/stryker-net) - Mutation testing for .NET Core projects
 * [xBehave.net](https://github.com/xbehave/xbehave.net) - An xUnit.net extension for describing your tests using natural language. [http://xbehave.github.io](http://xbehave.github.io)
 * [xUnit.net](https://github.com/xunit/xunit) - A free, open source, community-focused unit testing tool for the .NET Framework. [https://xunit.github.io/](https://xunit.github.io/)
 * [Canopy](https://github.com/lefthandedgoat/canopy) - Canopy is a free, open source F# web automation and testing framework 


### PR DESCRIPTION
Testing/Stryker.NET - [https://github.com/stryker-mutator/stryker-net](https://github.com/stryker-mutator/stryker-net)

Mutation testing for .NET Core projects

Solves issue #635. Because diverse tools and frameworks are listed in the testing category, I decided to add Stryker right here and not in a separate mutation testing category and therefore against the suggestion in the issue. 