### PR TITLE
Added new section: Strong Naming - starting with 'Strong Namer' library.

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ To the extent possible under law, [Vitali Fokin](https://github.com/quozd) has w
   * [SMS and Phone Calls](#sms-and-phone-calls)
   * [State machines](#state-machines)
   * [Static Site Generators](#static-site-generators)
+  * [Strong Naming](#strong-naming)
   * [Style Guide](#style-guide)
   * [Template Engine](#template-engine)
   * [Testing](#testing)
@@ -889,10 +890,15 @@ metadata in media files, including video, audio, and photo formats
 * [LiquidState](https://github.com/prasannavl/LiquidState) - Efficient asynchronous and synchronous state machines for .NET
 
 ## Static Site Generators
+
 * [FsBlog](https://github.com/fsprojects/FsBlog/) - Blog aware, static site generation using F#
 * [Pretzel](https://github.com/Code52/pretzel) - A site generation tool (and then some) for .NET platforms
 * [Sandra.Snow](https://github.com/Sandra/Sandra.Snow) - Jekyll-inspired static site generation for .NET
 * [Wyam](https://wyam.io/) - A simple to use, highly modular, and extremely configurable static content generator
+
+## Strong Naming
+
+* [Strong Namer](https://github.com/dsplaisted/strongnamer) - Automatically add strong names to referenced assemblies which do not already have a strong name. This will allow you to reference and use (NuGet packages with) assemblies which are not strong named from your projects that do use a strong name.
 
 ## Style Guide
 


### PR DESCRIPTION
Strong Naming/Strong Namer - [PROJECT_LINK](https://github.com/dsplaisted/strongnamer)

Automatically add strong names to referenced assemblies which do not already have a strong name. This will allow you to reference and use (NuGet packages with) assemblies which are not strong named from your projects that do use a strong name.
