### PR TITLE
add MsmqExts - a library for MSMQ Queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -825,6 +825,7 @@ metadata in media files, including video, audio, and photo formats
 * [RabbitMQ.NET](https://github.com/rabbitmq/rabbitmq-dotnet-client) - Implementation of an AMQP client library for C#, and a binding exposing AMQP services via WCF
 * [NetMQ](https://github.com/zeromq/netmq) - NetMQ is 100% native C# port of ZeroMQ
 * [MassTransit](https://github.com/MassTransit/MassTransit) - MassTransit is lean service bus implementation for building loosely coupled applications using the .NET Framework.
+* [MsmqExts](https://github.com/minhhungit/MsmqExts) - Library to work with MSMQ (Microsoft Message Queuing)
 * [Rebus](https://github.com/rebus-org/Rebus) - Rebus is a lean service bus implementation for .NET, similar in nature to NServiceBus and MassTransit, only leaner
 * [RestBus](https://github.com/tenor/RestBus) - A service-oriented .NET messaging library for RabbitMQ.
 * [RawRabbit](https://github.com/pardahlman/RawRabbit) - A modern .NET Core library for RabbitMQ.


### PR DESCRIPTION
QUEUE/MsmqExts - [https://github.com/minhhungit/MsmqExts](https://github.com/minhhungit/MsmqExts)

Library to work with MSMQ (Microsoft Message Queuing)
