### PR TITLE
StructureMap removed, Add Lamar

### DIFF
--- a/README.md
+++ b/README.md
@@ -597,7 +597,7 @@ the Python world. It uses the Pyro protocol to call methods on remote objects.
 * [Autofac](https://github.com/autofac/Autofac) - An addictive .NET IoC container
 * [DryIoc](https://github.com/dadhi/DryIoc) - Simple, fast all fully featured IoC container.
 * [Ninject](https://github.com/ninject/ninject) - The ninja of .NET dependency injectors
-* [StructureMap](https://structuremap.github.io/) - The original IoC/DI Container for .Net
+* [lamar](https://github.com/jasperfx/lamar/) - The original IoC/DI Container for .Net (Previously StructureMap)
 * [Spring.Net](https://github.com/spring-projects/spring-net) - Spring.NET is an open source application framework that makes building  enterprise .NET applications easier
 * [Lamar](https://jasperfx.github.io/lamar/) - A fast IoC container heavily optimized for usage within ASP.NET Core and other .NET server side applications.
 * [LightInject](https://github.com/seesharper/LightInject) - A ultra lightweight IoC container


### PR DESCRIPTION
CATEGORY/PROJECT_NAME - [PROJECT_LINK](PROJECT_LINK)
IOC
According to: https://github.com/structuremap/structuremap is not maintain anymore "StructureMap has been sunsetted"
Replace by https://github.com/jasperfx/lamar



