### PR TITLE
Added Cloudsmith (Package Management SaaS)

### DIFF
--- a/README.md
+++ b/README.md
@@ -786,6 +786,7 @@ metadata in media files, including video, audio, and photo formats
 
 * [NuGet](https://www.nuget.org/) - The .NET package manager
 * [BaGet](https://github.com/loic-sharma/BaGet/) - A cross-platform, lightweight NuGet and Symbol server
+* [Cloudsmith](https://cloudsmith.io/l/nuget-feed/) - A fully managed package management SaaS, with support for NuGet, Npm, Docker and much more. **[Free for Public/OSS]** **[$]**
 * [MyGet](https://www.myget.org/) - Hosted Package Repository for NuGet, NPM, Bower and VSIX. Also provides CI as-a-Service. **[$]**
 * [Paket](https://github.com/fsprojects/Paket) - A package dependency manager for .NET with support for NuGet packages and GitHub repositories. https://fsprojects.github.io/Paket/
 * [Sleet](https://github.com/emgarten/sleet/) - A NuGet v3 static feed generator with support for AWS S3 and Azure Storage


### PR DESCRIPTION
Package Management / [Cloudsmith](https://cloudsmith.io)

Hello! This adds [Cloudsmith](https://cloudsmith.io), which is a fully managed package management SaaS, with support for a full range of packaging technologies (but most recently, and importantly, NuGet). It's commercial, but is also completely free for open-source software and for public-only repositories.

Disclosure: I work for Cloudsmith, and I think it is awesome. :-)