### PR TITLE
Replace unofficial DropNet with official Dropbox.NET

### DIFF
--- a/README.md
+++ b/README.md
@@ -874,7 +874,7 @@ metadata in media files, including video, audio, and photo formats
 * [Azure PowerShell](https://github.com/Azure/azure-powershell) - A set of PowerShell cmdlets for developers and administrators to develop, deploy and manage Microsoft Azure applications
 * [Countly SDK for Windows](https://github.com/Countly/countly-sdk-windows/) - Windows SDK for Countly analytics and marketing platform for product and marketing managers
 * [Octokit.NET](https://github.com/octokit/octokit.net) - A GitHub API client library for .NET
-* [DropNet](https://github.com/DropNet/DropNet) - Client library for the Dropbox API
+* [Dropbox.NET](https://github.com/dropbox/dropbox-sdk-dotnet) - Official .NET SDK for the Dropbox API
 * [Getty Images API SDK](https://github.com/gettyimages/gettyimages-api_dotnet) - SDK for the Getty Images and iStock APIs
 
 ## Search


### PR DESCRIPTION
OLD (removed): 
DropNet - [https://github.com/DropNet/DropNet](https://github.com/DropNet/DropNet)

NEW (added):
Dropbox.NET - [https://github.com/dropbox/dropbox-sdk-dotnet](https://github.com/dropbox/dropbox-sdk-dotnet)

In the DropNet README:
DropNet is no longer under development and the current version of the library does not work with Dropbox API v2. I recommend moving to the official Dropbox .net SDK - https://github.com/dropbox/dropbox-sdk-dotnet


