### PR TITLE
Add JustCli

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,7 @@ To the extent possible under law, [Vitali Fokin](https://github.com/quozd) has w
 * [Docopt](https://github.com/docopt/docopt.net) - Command-line interface description language that will make you smile.
 * [EntryPoint](https://github.com/Nick-Lucas/EntryPoint) - Composable CLI Argument Parser for .NET Core & .NET Framework 4.5+.
 * [Fluent Command Line Parser](https://github.com/fclp/fluent-command-line-parser) - A simple, strongly typed .NET C# command-line parser library using a fluent easy to use interface
+* [JustCli](https://github.com/jden123/JustCli) - That’s just a quick way to create your own command line tool.
 * [Gui.cs](https://github.com/migueldeicaza/gui.cs) - Terminal UI toolkit for .NET.
 * [Power Args](https://github.com/adamabdelhamed/PowerArgs) - PowerArgs converts command-line arguments into .NET objects that are easy to program against. It also provides a ton of optional capabilities such as argument validation, auto generated usage, tab completion, and plenty of extensibility
 * [ReadLine](https://github.com/tonerdo/readline) - A GNU-Readline like library for .NET/.NET Core.


### PR DESCRIPTION
CLI/JustCli - [JustCli ](https://github.com/jden123/JustCli)

That’s just a quick way to create your own command line tool.

The idea is to have one command in one class. A set of attributes helps you to map command line arguments to the command class properties and provide additional information. JustCli scans your project, generates help and allows you to run the commands.

