### PR TITLE
Add a new websocket client library

### DIFF
--- a/README.md
+++ b/README.md
@@ -1066,6 +1066,7 @@ metadata in media files, including video, audio, and photo formats
 * [WampSharp](https://github.com/Code-Sharp/WampSharp) - A C# implementation of [The Web Application Messaging Protocol](https://wamp-proto.org/) - a protocol that provides messaging patterns of Remote Procedure Calls and Publish/Subscribe over WebSockets.
 * [NetGain](https://github.com/StackExchange/NetGain) - A high performance WebSocket server library powering Stack Overflow.
 * [Websockets.PCL](https://github.com/NVentimiglia/Websockets.PCL) - WebSockets.PCL is a portable class library, profile 259, C# WebSocket implementation.
+* [Websocket.Client](https://github.com/Marfusios/websocket-client) - A multiplatform wrapper over native C# class ClientWebSocket with built-in reconnection and error handling.
 
 ## Windows Services
 


### PR DESCRIPTION
Here we are again, one [year later](https://github.com/quozd/awesome-dotnet/pull/735) and over 100 stars. 

Webscoket/Websocket.Client - [PROJECT_LINK](https://github.com/Marfusios/websocket-client)

A wrapper over native C# class ClientWebSocket with built-in reconnection and error handling.