### PR TITLE
added JFlepp.Maybe

### DIFF
--- a/README.md
+++ b/README.md
@@ -457,6 +457,7 @@ To the extent possible under law, [Vitali Fokin](https://github.com/quozd) has w
 
 * [language-ext](https://github.com/louthy/language-ext) - This library uses and abuses the features of C# 6+ to provide a functional 'Base class library', that, if you squint, can look like extensions to the language itself. It also includes an 'Erlang like' process system (actors) that can optionally persist messages and state to Redis (note you can use it without Redis for in-app messaging). The process system additionally supports Rx streams of messages and state allowing for a complete system of reactive events and message dispatch.
 * [Optional](https://github.com/nlkl/Optional) - A robust option type for C#
+* [JFlepp.Maybe](https://github.com/jflepp/JFlepp.Maybe) - A Maybe type for C#, aimed as an idiomatic port of the option type in F# to C#
 
 ## Game
 


### PR DESCRIPTION
Functional Programming/JFlepp.Maybe - [GitHub](https://github.com/jflepp/JFlepp.Maybe)

A Maybe type for C#, aimed as an idiomatic port of the option type in F# to C#