### PR TITLE
add Devtodev sdk

### DIFF
--- a/README.md
+++ b/README.md
@@ -468,6 +468,7 @@ To the extent possible under law, [Vitali Fokin](https://github.com/quozd) has w
 * [UrhoSharp](https://github.com/xamarin/urho) - UrhoSharp is a C# implementation of the Urho3D game engine that runs on iOS, Mac, Windows, Android and Linux systems
 * [Nez](https://github.com/prime31/Nez) - Nez is a free 2D-focused framework that works with MonoGame and FNA
 * [BEPUphysics](https://github.com/bepu/bepuphysics2) - BEPUphysics is a pure C# 3D physics library
+* [Devtodev] (https://github.com/devtodev-analytics/winstore-sdk) - A full-cycle analytics solution for game developers.
 
 ## GIS
 


### PR DESCRIPTION
Game/Devtodev - [Devtodev](https://github.com/devtodev-analytics/winstore-sdk)

devtodev (https://www.devtodev.com/) is an analytical platform developed by games industry professionals specifically for game developers. With devtodev, you can convert players into paying users, improve in-game economics, predict churn, revenue and customer lifetime value, as well as analyze and influence user behavior.
