### PR TITLE
Add Optuple

### DIFF
--- a/README.md
+++ b/README.md
@@ -458,6 +458,7 @@ To the extent possible under law, [Vitali Fokin](https://github.com/quozd) has w
 * [language-ext](https://github.com/louthy/language-ext) - This library uses and abuses the features of C# 6+ to provide a functional 'Base class library', that, if you squint, can look like extensions to the language itself. It also includes an 'Erlang like' process system (actors) that can optionally persist messages and state to Redis (note you can use it without Redis for in-app messaging). The process system additionally supports Rx streams of messages and state allowing for a complete system of reactive events and message dispatch.
 * [Optional](https://github.com/nlkl/Optional) - A robust option type for C#
 * [JFlepp.Maybe](https://github.com/jflepp/JFlepp.Maybe) - A Maybe type for C#, aimed as an idiomatic port of the option type in F# to C#
+* [Optuple](https://github.com/atifaziz/Optuple) - .NET Standard Library for giving `(bool, T)` Option-like semantics in a non-obtrusive way; this is, there is no new option type dependency for a library or its users.
 
 ## Game
 


### PR DESCRIPTION
## [Functional Programming](https://github.com/quozd/awesome-dotnet/tree/eeefc30b0b7467125a2b69a2d7149b93fa8998e6#functional-programming)/[Optuple](https://github.com/atifaziz/Optuple)

### What is it?

Optuple is a .NET Standard library that enables a tuple of Boolean and some type (`T`), i.e. `(bool, T)`, to have the same semantics as an option type found in most functional languages.

Optuple, however, does not define any such type. Instead it primarily supplies extension methods for any `(bool, T)` (like `Match`, `Map` and more) to be treated like an option type. Suppose a value `x` of type `T`, then `(true, x)` will be treated like `Some x` and `(false, _)` will be treated like `None`.

### Why is it awesome?

If you don't mind tooting my own horn…

A library that wants to expose optional values needs _no dependency_ on Optuple. It can just expose `(bool, T)` for some type `T`. The client of the library can use Optuple independently to get &ldquo;optional semantics&rdquo;.

This is a unique twist. Curious folks like @mikehadlow have [wondered the same](https://twitter.com/mikehadlow/status/1194570824176545792).
