### PR TITLE
Add Excepticon

### DIFF
--- a/README.md
+++ b/README.md
@@ -452,6 +452,7 @@ To the extent possible under law, [Vitali Fokin](https://github.com/quozd) has w
 * [FluentMediator](https://github.com/ivanpaulovich/FluentMediator) - FluentMediator is an unobtrusive library that allows developers to build custom pipelines for Commands, Queries and Events
 
 ## Exceptions
+* [Excepticon](https://github.com/Excepticon/excepticon-dotnet) - Exception monitoring service for .NET applications and services
 * [Exceptionless](https://github.com/exceptionless/Exceptionless.Net) - Exceptionless .NET Client
 
 ## Extensions


### PR DESCRIPTION
Excepticon - [https://github.com/Excepticon/excepticon-dotnet](https://github.com/Excepticon/excepticon-dotnet)

PROJECT_DESCRIPTION

Excepticon is an exception monitoring service for .NET applications and services.  Geared towards small/indie devs, Excepticon is free forever for side projects.
