### PR TITLE
Add DEM Net Elevation API

### DIFF
--- a/README.md
+++ b/README.md
@@ -485,6 +485,7 @@ To the extent possible under law, [Vitali Fokin](https://github.com/quozd) has w
  * [GeoJSON4EntityFramework](https://github.com/alatas/GeoJSON4EntityFramework) - A library to create GeoJSON from Entity Framework Spatial Data or Well-Known Text (WKT) inputs.
  * [GeoJSON.NET](https://github.com/GeoJSON-Net/GeoJSON.Net) - .Net library for GeoJSON types & corresponding Json.Net (de)serializers
  * [CoordinateSharp](https://github.com/Tronald/CoordinateSharp) - Easily parse or convert coordinate formats and calculate location based solar/lunar information.
+ * [DEM Net Elevation API](https://github.com/dem-net/dem.net) - .Net library for Digital Elevation Models, allows 3D terrain generation in glTF / STL format.
 
 ## Git Tools
 


### PR DESCRIPTION
GIS/DEM Net Elevation API - [https://github.com/dem-net/DEM.Net](https://github.com/dem-net/DEM.Net)

PROJECT_DESCRIPTION

.Net library for Digital Elevation Models, allows 3D terrain generation in glTF / STL format.
