### PR TITLE
Added SignalR.EasyUse

### DIFF
--- a/README.md
+++ b/README.md
@@ -1072,6 +1072,7 @@ metadata in media files, including video, audio, and photo formats
 
 * [Fleck](https://github.com/statianzo/Fleck) - Fleck is a WebSocket server implementation in C#. Branched from the Nugget project
 * [SignalR](https://github.com/SignalR/SignalR) - Library for ASP.NET developers that makes it incredibly simple to add real-time web functionality to your applications
+* [SignalR.EasyUse](https://github.com/Kibnet/SignalR.EasyUse) - A framework that allows to use SignalR easy, following the strict contracts out of box. To get the maximal benefit the client application must be written in C#.
 * [SuperSocket](https://github.com/kerryjiang/SuperSocket) - SuperSocket is a light weight extensible socket application framework
 * [Websocket-Sharp](https://github.com/sta/websocket-sharp) - A C# implementation of the WebSocket protocol client and server
 * [WebSocket4NET](https://archive.codeplex.com/?p=websocket4net) - WebSocket client for .NET 2.0+, Xamarin, Mono, Silverlight, Windows Phone, & WinRT


### PR DESCRIPTION
WebSocket - [SignalR.EasyUse](https://github.com/Kibnet/SignalR.EasyUse)

A framework that allows to use SignalR easy, following the strict contracts out of box. To get the maximal benefit the client application must be written in C#.