### PR TITLE
Add Tecan SiLA2 SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -856,6 +856,7 @@ metadata in media files, including video, audio, and photo formats
 * [SharpSnmpLib](https://docs.sharpsnmp.com/) - An open source SNMP implementation for .NET/Mono/Xamarin. Versioin 1, 2c, and 3 are supported.
 * [DNS](https://github.com/kapetan/dns) - A library for parsing and serializing DNS messages. Includes a basic DNS client and server.
 * [DnsClient.NET](https://github.com/MichaCo/DnsClient.NET) - A simple yet very powerful and high performant open source library for the .NET Framework to do DNS lookups.
+* [Tecan SiLA2 SDK](https://gitlab.com/SiLA2/vendors/sila_tecan) - A library and code generator to develop SiLA2 clients and servers.
 
 ## Push Notifications
 


### PR DESCRIPTION
SiLA2 is a quite recent standard in lab automation and the Tecan SiLA2 SDK is a project that aims to make it as easy as possible to create a SiLA2 server or client. It is licensed under BSD-3.
