### PR TITLE
Add Docotic.Pdf reference to the PDF section

### DIFF
--- a/README.md
+++ b/README.md
@@ -838,7 +838,8 @@ metadata in media files, including video, audio, and photo formats
 ## PDF
 
 * [Cloudmersive PDF](https://cloudmersive.com/pdf-api) - Cloudmersive PDF is a native .NET Framework and .NET Core NuGet library and API service that can create, modify, encrypt or convert PDF documents at high scale and fidelity; and is free to use with no expiration **[Free]**
-* [ITextSharp](https://github.com/itext/itextsharp) - iText is a PDF library that allows you to CREATE, ADAPT, INSPECT and MAINTAIN documents in the Portable Document Format (PDF)**[$]****[Free for OSS]**
+* [Docotic.Pdf](https://bitmiracle.com/pdf-library/) - PDF library to create, read, edit, draw, and print PDF documents in .NET and .NET Core applications. 100% managed, without unsafe blocks. **[$]** **[[Free for OSS](https://bitmiracle.com/pdf-library/free-pdf-library.aspx)]**
+* [ITextSharp](https://github.com/itext/itextsharp) - iText is a PDF library that allows you to CREATE, ADAPT, INSPECT and MAINTAIN documents in the Portable Document Format (PDF)**[$]** **[Free for OSS]**
 * [PdfiumViewer](https://github.com/pvginkel/PdfiumViewer) - PdfiumViewer is a PDF viewer based on the PDFium project.
 * [WkhtmlToPdf](https://github.com/codaxy/wkhtmltopdf) - C# wrapper around wkhtmltopdf console utility. Allow to generate preety PDF using HTML and CSS.
 * [Pdfium.Net SDK](https://pdfium.patagames.com/) - Advanced C# PDF library for render, create, edit, merge, split, print, and view PDFs. Open source PDF Viewer is available on [GitHub](https://github.com/patagames). A [NuGet package](https://www.nuget.org/packages/Pdfium.Net.SDK/) is also available for easy inclusion into your projects.**[$]**


### PR DESCRIPTION
PDF/Docotic.Pdf - [https://bitmiracle.com/pdf-library/](https://bitmiracle.com/pdf-library/)

Docotic.Pdf is a .NET PDF library to create, read, edit, draw, and print PDF documents. Free for use in non-commercial open-source projects.

Please note that this PR also fixes markup for iTextSharp description (added missing space between ** and ** ).

--

Additional information about Docotic.Pdf to simplify your moderation:
* Presented on the market [since 2010](https://bitmiracle.com/pdf-library/help/version-history.html)
* Free trial mode. Free 30 day evaluation of fully-functional version (https://bitmiracle.com/pdf-library/download-pdf-library.aspx)
* Actively maintained. You can find history of stable and development releases [on NuGet](https://www.nuget.org/packages/BitMiracle.Docotic.Pdf/)