### PR TITLE
Update Sharplab's description.

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ To the extent possible under law, [Vitali Fokin](https://github.com/quozd) has w
 
 * [.NET Fiddle](https://dotnetfiddle.net/) - Write, compile and run C#, F# and VB code in the browser. The .Net equivalent of JSFiddle.
 * [Gistlyn](https://gistlyn.com/) - Create, run and share your executable C# GitHub Gists.
-* [TryRoslyn](https://sharplab.io/) - Run C# code using different branches and versions of Roslyn.
+* [Sharplab](https://sharplab.io/) - Run C# code using different branches and versions of Roslyn, see the IL that was produced and examine the JIT's output.
 
 ## Compilers, Transpilers and Languages
 


### PR DESCRIPTION
Code Snippets/Sharplab (former TryRoslyn)

This PR updates the description for Sharplab to mention one of its more common use cases - examining assembly produced by the JIT.