### PR TITLE
.NET Assembly Strong-Name Signer

### DIFF
--- a/README.md
+++ b/README.md
@@ -959,6 +959,7 @@ metadata in media files, including video, audio, and photo formats
 ## Strong Naming
 
 * [Strong Namer](https://github.com/dsplaisted/strongnamer) - Automatically add strong names to referenced assemblies which do not already have a strong name. This will allow you to reference and use (NuGet packages with) assemblies which are not strong named from your projects that do use a strong name.
+* [.NET Assembly Strong-Name Signer](https://github.com/brutaldev/StrongNameSigner) - Utility software to strong-name sign .NET assemblies, including assemblies you do not have the source code for. 
 
 ## Style Guide
 


### PR DESCRIPTION
Strong Naming/.NET Assembly Strong-Name Signer - [.NET Assembly Strong-Name Signer](https://github.com/brutaldev/StrongNameSigner)

PROJECT_DESCRIPTION

<!--
  Utility software to strong-name sign .NET assemblies, including assemblies you do not have the source code for. If you strong-name sign your own projects you may have noticed that if you reference an unsigned third party assembly you get an error similar to "Referenced assembly 'A.B.C' does not have a strong name". If you did not create this assembly, you can use this tool to sign the assembly with your own (or temporarily generated) strong-name key. The tool will also re-write the assembly references (as well as any InternalsVisibleTo references) to match the new signed versions of the assemblies you create.
-->
