### PR TITLE
Add MKL.NET

### DIFF
--- a/README.md
+++ b/README.md
@@ -705,6 +705,7 @@ the Python world. It uses the Pyro protocol to call methods on remote objects.
 * [AutoDiff](https://github.com/alexshtf/autodiff) - AutoDiff is a library for quickly computing gradients of functions defined by expressions. Mainly useful in numerical optimization
 * [GeometRi](https://github.com/RiSearcher/GeometRi.CSharp) - Simple and lightweight computational geometry library for .Net
 * [Rationals](https://github.com/tompazourek/Rationals) - Implementation of rational number arithmetic for .NET with arbitrary precision.
+* [MKL.NET](https://github.com/AnthonyLloyd/MKL.NET) - A simple cross platform .NET API for Intel MKL.
 
 ## Media
 


### PR DESCRIPTION
Mathematics/MKL.NET - [https://github.com/AnthonyLloyd/MKL.NET](https://github.com/AnthonyLloyd/MKL.NET)

A simple cross platform .NET API for Intel MKL

Exposing functions from MKL keeping the syntax as close to the
[c developer reference](https://software.intel.com/content/www/us/en/develop/documentation/mkl-developer-reference-c/top.html) as possible.

Reference the MKL.NET package and required runtime packages and use the static MKL functions.
The correct native libraries will be included and loaded at runtime.