### PR TITLE
Add OctoLinker browser extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -1033,6 +1033,7 @@ metadata in media files, including video, audio, and photo formats
 * [SmartCode](https://github.com/dotnetcore/SmartCode) - SmartCode = IDataSource -> IBuildTask -> IOutput => Build Everything!!! (Including [**Code generator**])
 * [NETworkManager](https://github.com/BornToBeRoot/NETworkManager) - A powerful tool for managing networks and troubleshoot network problems!
 * [AnyStatus](https://www.anystat.us) - A desktop notifications app for monitoring CI/CD pipelines, servers, network, health and metrics. AnyStatus supports Azure DevOps, Jenkins, TeamCity, AppVeyor and more.
+* [OctoLinker](https://github.com/OctoLinker/OctoLinker) - Navigate through `project.json`, `packages.config`, `*.props`, `*.targets`, and C#/F#/VB.NET project files efficiently with the OctoLinker browser extension for GitHub.
 
 ## Trading
 


### PR DESCRIPTION
Tools/OctoLinker - [https://github.com/OctoLinker/OctoLinker](https://github.com/OctoLinker/OctoLinker)

Navigate through `project.json`, `packages.config`, `*.props`, `*.targets`, and C#/F#/VB.NET project files efficiently with the OctoLinker browser extension for GitHub.

This was declined in #428, but since then a bunch of new .net support was added such as:

- `dotnet-tools.json` (local tool configs)
- `packages.config`
- `Directory.Build.props`
- `Directory.Build.targets`
- `*.csproj`, `*.fsproj`, and `*.vbproj` files

The project files, `*.props`, and `*.targets` files support `PackageReference` as well as `Compile`, `Content`, `EmbeddedResource`, `None`, `DotNetCliToolReference`, and `FrameworkReference` elements.

Support for [Paket](https://fsprojects.github.io/Paket/) is in the works and will hopefully be in the next release.

/cc @stefanbuck