### PR TITLE
Added the NCC FreeSql to the list of ORMs

### DIFF
--- a/README.md
+++ b/README.md
@@ -820,6 +820,7 @@ metadata in media files, including video, audio, and photo formats
 * [Dapper](https://github.com/StackExchange/Dapper) - A simple object mapper for .NET by [StackExchange](https://stackexchange.github.io/)
 * [Dapper Extensions](https://github.com/tmsmith/Dapper-Extensions) - Small library that complements Dapper by adding basic CRUD operations (Get, Insert, Update, Delete) for your POCOs
 * [Dapper.FastCRUD](https://github.com/MoonStorm/Dapper.FastCRUD) - The fastest micro-ORM extension for Dapper
+* [FreeSql](https:/githun.com/dotnetcore/FreeSql) - a convenient ORM in dotnet, supports MySql, SqlServer, PostgreSQL, Oracle, Sqlite, Firebird, 达梦, 人大金仓, 神舟通用, 翰高 and Access.
 * [NHibernate](https://github.com/nhibernate) - NHibernate Object Relational Mapper
 * [Fluent NHibernate](https://github.com/nhibernate/fluent-nhibernate) - Fluent, XML-less, compile safe, automated, convention-based mappings for NHibernate.
 * [FluentMigrator](https://github.com/fluentmigrator/fluentmigrator) - Fluent Migrations framework for .net


### PR DESCRIPTION
FreeSql is currently used by many Chinese developers, including in the projects of many commercial companies. Users who have used FreeSql said that he is even better than EFCore:

> EFCore is excellent, and FreeSql stands on the shoulders of giants.

We will work hard to internationalize FreeSql's documentation so that more developers can understand and use it.

Project Repo: https://github.com/dotnetcore/FreeSql