### PR TITLE
Update dotnet/runtime description

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ To the extent possible under law, [Vitali Fokin](https://github.com/quozd) has w
 
 ## CLR
 
-* [Runtime](https://github.com/dotnet/runtime) - The runtime repo contains the complete runtime implementation (called "CoreCLR") for .NET Core. It includes RyuJIT, the .NET GC, native interop and many other components.
+* [Runtime](https://github.com/dotnet/runtime) - Mono and CoreCLR .NET runtimes, as well as the standard library and some higher level components like `System.Linq` and `System.Text.Json`.
 
 ## CMS
 


### PR DESCRIPTION
This PR updates the description of `dotnet/runtime` to mention that it now includes Mono and the BCL.
CoreCLR specific bits were cut for the purposes of brevity, but whether that's desirable I leave to the discretion of maintainers. I personally do not have a strong opinion on the matter and can add as much detail as will determined to be needed (on the CoreCLR side of things at least, but Mono can be figured out as well).

I decided to leave the `host` part of `dotnet/runtime` out as it is arguably too obscure a concept to be included in this list.
