### PR TITLE
ISS-987: Remove SharpDox repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -426,7 +426,6 @@ To the extent possible under law, [Vitali Fokin](https://github.com/quozd) has w
 ## Documentation
 
 * [Sandcastle](https://github.com/EWSoftware/SHFB) - Sandcastle Help File Builder similar to NDoc
-* [SharpDox](https://github.com/Geaz/sharpDox) - A C# documentation tool
 * [SourceBrowser](https://github.com/KirillOsenkov/SourceBrowser) - Source browser website generator that powers https://referencesource.microsoft.com
 * [Swashbuckle](https://github.com/domaindrivendev/Swashbuckle.WebApi) - Seamlessly adds a Swagger to Web API projects.
 * [F# Formatting](https://fsprojects.github.io/FSharp.Formatting/) - Tools for documenting F# and C# projects from F# script files, Markdown documents and inline XML or Markdown comments


### PR DESCRIPTION
Removed **Documentation/SharpDox**.

The Documentation/SharpDox repository has been archived for almost 3 years, its http://sharpdox.de site is not accessed and one of link in README file is broken. I think it is not actual.

Closes #988 