### PR TITLE
Add m2cgen for transpiling ML models into .NET

### DIFF
--- a/README.md
+++ b/README.md
@@ -716,6 +716,7 @@ the Python world. It uses the Pyro protocol to call methods on remote objects.
 * [Spreads](https://github.com/Spreads/Spreads/) - Series and Panels for Real-time and Exploratory Analysis of Data Streams. Spreads library is optimized for performance and memory usage. It is several times faster than other open source projects.
 * [SciSharp STACK](https://scisharp.github.io/SciSharp/) - A rich machine learning ecosystem for .NET created by porting the most popular Python libraries to C#.
 * [Synapses](https://github.com/mrdimosthenis/Synapses) - An in-memory neural network library written in F#.
+* [m2cgen](https://github.com/BayesWitnesses/m2cgen) - A CLI tool to transpile trained classic ML models into a native .NET (C#, F# or Visual Basic) code with zero dependencies.
 
 ## Markdown Processors
 * [MarkdownSharp](https://code.google.com/archive/p/markdownsharp) - Open source C# implementation of Markdown processor, as featured on Stack Overflow.


### PR DESCRIPTION
Machine Learning/m2cgen - [https://github.com/BayesWitnesses/m2cgen](https://github.com/BayesWitnesses/m2cgen)

---

`m2cgen` is a lightweight library with command line interface which allows to transpile trained machine learning models into a native code of C# / F# / Visual Basic programming language. Examples of generated code can be found [here](https://github.com/BayesWitnesses/m2cgen/tree/master/generated_code_examples).
