### PR TITLE
Added Build Versioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -819,6 +819,7 @@ metadata in media files, including video, audio, and photo formats
 * [Coravel](https://github.com/jamesmh/coravel) Near-zero config .NET Core library that makes Task Scheduling, Caching, Queuing, Mailing, Event Broadcasting (and more) a breeze!
 * [Quickenshtein](https://github.com/Turnerj/Quickenshtein) - An extremely quick and memory efficient Levenshtein Distance calculator with SIMD and Threading support
 * [Infinity Crawler](https://github.com/TurnerSoftware/InfinityCrawler) - A simple but powerful web crawler library for .NET
+* [Build Versioning](https://github.com/TurnerSoftware/BuildVersioning) - Simple build versioning for .NET, powered by Git tags
 
 ## MVVM
 


### PR DESCRIPTION
Misc/Build Versioning - [https://github.com/TurnerSoftware/BuildVersioning](https://github.com/TurnerSoftware/BuildVersioning)

Simple build versioning for .NET, powered by Git tags. Out-of-the-box, it provides pre-release and build metadata from the current CI environment. So for pull requests, this will automatically have a pre-release defined which will include the PR number (eg. `1.2.4-pr.17`). For all commits, the build metadata will include the CI environment and a relevant build identifier (eg. `1.2.4+a4f31ea-github.432515`).

-----

I was on the fence whether this would be best in Misc, Git Tools or just Tools - happy to adjust if this isn't the best category.