### PR TITLE
Add ReHackt.RazorEmails

### DIFF
--- a/README.md
+++ b/README.md
@@ -748,6 +748,7 @@ the Python world. It uses the Pyro protocol to call methods on remote objects.
 * [MimeKit](https://github.com/jstedfast/MimeKit) - A cross-platform .NET MIME creation and parser library with support for S/MIME, PGP, TNEF and Unix mbox spools.
 * [PreMailer.Net](https://github.com/milkshakesoftware/PreMailer.Net) - C# library that moves your stylesheets to inline style attributes, for maximum compatibility with e-mail clients.
 * [StrongGrid](https://github.com/Jericho/StrongGrid) - Client for SendGrid's v3 API. Not only allows you to send emails, but also allows you to bulk import contacts, manage lists and segments, create custom fields for your lists, etc. Also includes a parser for SendGrid Webhooks.
+* [ReHackt.RazorEmails](https://github.com/LionelVallet/ReHackt.RazorEmails) - Provides an email layout to create email templates with Razor and tag helpers, and a service to send emails using SMTP.
 
 ## Mathematics
 


### PR DESCRIPTION
Mail/ReHackt.RazorEmails - [ReHackt.RazorEmails](https://github.com/LionelVallet/ReHackt.RazorEmails)

Provides an email layout to create email templates with Razor and tag helpers, and a service to send emails using SMTP.