### PR TITLE
Add FlatSharp

### DIFF
--- a/README.md
+++ b/README.md
@@ -1017,6 +1017,7 @@ metadata in media files, including video, audio, and photo formats
 * [Msgpack-Cli](https://github.com/msgpack/msgpack-cli) - MessagePack implementation for Common Language Infrastructure
 * [Jil](https://github.com/kevin-montrose/Jil) - Fast .NET JSON serializer, built on Sigil (used by StackOverflow)
 * [ProtoBuf](https://github.com/SilentOrbit/protobuf) - Generate C# code for protocol buffer serialization from a .proto specification.
+* [FlatSharp](https://github.com/jamescourtney/FlatSharp) - Fast, idiomatic FlatBuffers implementation. Use .fbs files or attributes.
 * [F# Data](https://fsharp.github.io/FSharp.Data/) - F# type providers for accessing XML, JSON, CSV and HTML files (based on sample documents) and for accessing WorldBank data
 * [Bond](https://github.com/Microsoft/bond) - cross-platform framework for working with schematized data. It supports cross-language de/serialization and powerful generic mechanisms for efficiently manipulating data.
 * [Hyperion](https://github.com/akkadotnet/Hyperion) - A high performance polymorphic serializer for the .NET framework.


### PR DESCRIPTION
Serialization/FlatSharp - [https://github.com/jamescourtney/FlatSharp](https://github.com/jamescourtney/FlatSharp)

FlatSharp is a pure-C# implementation of Google's FlatBuffer serialization format. FlatSharp is focused on being idoimatic and performant. FlatSharp supports zero-copy deserialization, lazy access, and is extremely fast.

I'm not sure on the ordering of the list, so I put it next to the F# package.