### PR TITLE
Remove Kestrel

### DIFF
--- a/README.md
+++ b/README.md
@@ -1188,7 +1188,6 @@ metadata in media files, including video, audio, and photo formats
 
 ## Web Servers
 
-* [Kestrel](https://github.com/aspnet/KestrelHttpServer) -  A web server for ASP.NET Core based on libuv
 * [EmbedIO](https://github.com/unosquare/embedio) - Web server built on Mono and cross-platform
 * [XSP](https://github.com/mono/xsp) - Mono's ASP.NET hosting server. This module includes an Apache Module, a FastCGI module that can be hooked to other web servers as well as a standalone server used for testing (similar to Microsoft's Cassini)
 


### PR DESCRIPTION
It has been integrated into asp.net core and be the default server. The standalone repo has been archived. Besides now it's not based on libuv.