### PR TITLE
Add NCrontab.Scheduler to list of Schedulers

### DIFF
--- a/README.md
+++ b/README.md
@@ -995,6 +995,7 @@ metadata in media files, including video, audio, and photo formats
 
 * [FluentScheduler](https://github.com/fluentscheduler/FluentScheduler) - Task scheduler with fluent interface that runs automated jobs from your application
 * [NCrontab](https://github.com/atifaziz/NCrontab) - Class library for parsing & formatting [crontab](http://crontab.org/) expressions as well as calculating occurrences of time based on a crontab schedule
+* [NCrontab.Scheduler](https://github.com/thomasgalliker/NCrontab.Scheduler) - Simple task scheduler library for scheduling NCrontab-based tasks
 * [QuartzNet](https://github.com/quartznet/quartznet) - Quartz Enterprise Scheduler .NET
 * [Hangfire](https://github.com/HangfireIO) - An easy way to perform fire-and-forget, delayed and recurring tasks inside .NET apps
 * [Chroniton](https://github.com/leosperry/Chroniton) - A simple, fully integrable, and customizable library for running strongly typed jobs (tasks) on schedules.


### PR DESCRIPTION
Schedulers/NCrontab.Scheduler - [https://github.com/thomasgalliker/NCrontab.Scheduler](https://github.com/thomasgalliker/NCrontab.Scheduler)

NCrontab.Scheduler is a simple, open source task scheduling system based on NCrontab. It's absolutely awesome, unit tested and used in production software.
