### PR TITLE
Add SlimMessageBus

### DIFF
--- a/README.md
+++ b/README.md
@@ -990,6 +990,7 @@ metadata in media files, including video, audio, and photo formats
 * [Kafunk](https://github.com/jet/kafunk) - F# Kafka client from Jet
 * [Brighter](https://github.com/BrighterCommand/Brighter) - Command Dispatcher, Processor, and Distributed Task Queue https://www.goparamore.io/
 * [Silverback](https://silverback-messaging.net) - A simple but feature-rich message bus for .NET core (supports Kafka, RabbitMQ and MQTT).
+* [SlimMessageBus](https://github.com/zarusz/SlimMessageBus) - Lightweight message bus with transports for popular messaging systems (Kafka, Redis, Azure Service Bus, and others) and in-memory communication.
 
 ## RPC
 


### PR DESCRIPTION
Queue/SlimMessageBus - [https://github.com/zarusz/SlimMessageBus](https://github.com/zarusz/SlimMessageBus)

Lightweight message bus with transports for popular messaging systems (Kafka, Redis, Azure Service Bus, and others) and in-memory communication.

<!--
  Please, fill in this PR template. It will help maintainers to do the review.
  Also, please read our [Contribution guidelines](CONTRIBUTING.md). 
  Please, create one pull request per link.
-->

Signed-off-by: Tomasz Maruszak <maruszaktomasz@gmail.com>