### PR TITLE
Add NetArchTest

### DIFF
--- a/README.md
+++ b/README.md
@@ -1114,6 +1114,7 @@ metadata in media files, including video, audio, and photo formats
 ## Testing
 
 * [ArchUnitNET](https://github.com/TNG/ArchUnitNET) - Simple library for checking the architecture of C# code with a fluent API.
+* [NetArchTest](https://github.com/BenMorris/NetArchTest) - A fluent API for .Net Standard that can enforce architectural rules in unit tests.
 * [AutoFixture](https://github.com/AutoFixture/AutoFixture) - AutoFixture is an open source framework for .NET designed to minimize the 'Arrange' phase of your unit tests
 * [BDTest](https://github.com/thomhurst/BDTest/wiki) - A behaviour driven testing and reporting framework!
 * [BDDfy](https://github.com/TestStack/TestStack.BDDfy) - BDDfy is the simplest BDD framework EVER!


### PR DESCRIPTION
Testing/[NetArchTest](https://github.com/BenMorris/NetArchTest)

A fluent API for .Net Standard that can enforce architectural rules in unit tests.
Inspired by the [ArchUnit](https://www.archunit.org/) library for Java.
