### PR TITLE
Added Morestachio Templating Engine Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1111,6 +1111,7 @@ metadata in media files, including video, audio, and photo formats
 * [DotLiquid](https://github.com/dotliquid/dotliquid) - C# port of the Ruby Liquid templating language
 * [Mustache Sharp](https://github.com/jehugaleahsa/mustache-sharp) - An extension of the mustache text template engine for .NET.
 * [Scriban](https://github.com/lunet-io/scriban) - A fast, powerful, safe and lightweight text templating language and engine for .NET
+* [Morestachio](https://github.com/JPVenson/morestachio) - A full sized {{mustache}} like template engine with focus on extendibility.
 
 ## Testing
 


### PR DESCRIPTION
Added Morestachio TextTemplating engine Link

Template Engine/Morestachio - [https://github.com/JPVenson/morestachio](https://github.com/JPVenson/morestachio)

A Text Templating engine written in C# that build upon the {{mustache}} syntax with a very c# like flavor by adding complex paths, extensive formatting instructions and a great deal of extensibility with C# interoperability. 
