### PR TITLE
Remove Gistlyn (Dead Link)

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,7 +346,6 @@ To the extent possible under law, [Vitali Fokin](https://github.com/quozd) has w
 ## Code Snippets
 
 * [.NET Fiddle](https://dotnetfiddle.net/) - Write, compile and run C#, F# and VB code in the browser. The .Net equivalent of JSFiddle.
-* [Gistlyn](https://gistlyn.com/) - Create, run and share your executable C# GitHub Gists.
 * [Sharplab](https://sharplab.io/) - Run C# code using different branches and versions of Roslyn, see the IL that was produced and examine the JIT's output.
 
 ## Compilers, Transpilers and Languages


### PR DESCRIPTION
The Gistlyn (https://gistlyn.com/) site is dead. Seems the domain has been sold.

```
* [Gistlyn](https://gistlyn.com/) - Create, run and share your executable C# GitHub Gists.
```
