### PR TITLE
Add Jodo.Numerics

### DIFF
--- a/README.md
+++ b/README.md
@@ -791,7 +791,7 @@ the Python world. It uses the Pyro protocol to call methods on remote objects.
 * [AngouriMath](https://github.com/asc-community/AngouriMath) - An open-source symbolic/computer algebra library, made primarily for C# and F#. It covers a range of features and might be considered as an alternative to SymPy in .NET.
 * [Vim.Math3d](https://github.com/vimaec/math3d) - A feature-rich cross-platform replacement for System.Numerics with support for consistent serialization and binary layout, and additional structures and algorithms for efficient 3D Math. 
 * [WPF-Math](https://github.com/ForNeVeR/wpf-math) - a .NET library for rendering mathematical formulae using the LaTeX typesetting style, for the WPF framework
-* [Jodo.Numerics](https://github.com/JosephJShort/Jodo/#3-jodonumerics) - Provides a fully-featured generic interface for number types, supporting operators, math, conversion, parsing, random generation etc. Includes several custom number types such as fixed-point and non-overflowing numbers.
+* [Jodo.Numerics](https://github.com/JosephJShort/Jodo/#numerics) - Provides a fully-featured generic interface for number types, supporting operators, math, conversion, parsing, random generation etc. Includes several custom number types such as fixed-point and non-overflowing numbers.
 
 ## Media
 

--- a/README.md
+++ b/README.md
@@ -791,6 +791,7 @@ the Python world. It uses the Pyro protocol to call methods on remote objects.
 * [AngouriMath](https://github.com/asc-community/AngouriMath) - An open-source symbolic/computer algebra library, made primarily for C# and F#. It covers a range of features and might be considered as an alternative to SymPy in .NET.
 * [Vim.Math3d](https://github.com/vimaec/math3d) - A feature-rich cross-platform replacement for System.Numerics with support for consistent serialization and binary layout, and additional structures and algorithms for efficient 3D Math. 
 * [WPF-Math](https://github.com/ForNeVeR/wpf-math) - a .NET library for rendering mathematical formulae using the LaTeX typesetting style, for the WPF framework
+* [Jodo.Numerics](https://github.com/JosephJShort/Jodo/#3-jodonumerics) - Provides a fully-featured generic interface for defining customer number types, along with examples such as fixed-point numbers. The project emphasises reliability and an intuitive API.
 
 ## Media
 

--- a/README.md
+++ b/README.md
@@ -795,7 +795,7 @@ the Python world. It uses the Pyro protocol to call methods on remote objects.
 
 ## Media
 
-* [CSdCore](https://github.com/filoe/cscore) - An advanced audio library, supporting playback/recording, decoding/encoding and processing of audio data in realtime (effects, visualizations, ...).
+* [CSCore](https://github.com/filoe/cscore) - An advanced audio library, supporting playback/recording, decoding/encoding and processing of audio data in realtime (effects, visualizations, ...).
 * [TagLib#](https://github.com/mono/taglib-sharp) - TagLib# (aka taglib-sharp) is a library for reading and writing
 metadata in media files, including video, audio, and photo formats
 * [LibVLCSharp](https://github.com/videolan/libvlcsharp) - Xamarin bindings for libvlc, the multimedia framework powering the VLC applications made by VideoLAN.

--- a/README.md
+++ b/README.md
@@ -791,11 +791,11 @@ the Python world. It uses the Pyro protocol to call methods on remote objects.
 * [AngouriMath](https://github.com/asc-community/AngouriMath) - An open-source symbolic/computer algebra library, made primarily for C# and F#. It covers a range of features and might be considered as an alternative to SymPy in .NET.
 * [Vim.Math3d](https://github.com/vimaec/math3d) - A feature-rich cross-platform replacement for System.Numerics with support for consistent serialization and binary layout, and additional structures and algorithms for efficient 3D Math. 
 * [WPF-Math](https://github.com/ForNeVeR/wpf-math) - a .NET library for rendering mathematical formulae using the LaTeX typesetting style, for the WPF framework
-* [Jodo.Numerics](https://github.com/JosephJShort/Jodo/#3-jodonumerics) - Provides a fully-featured generic interface for defining customer number types with examples such as fixed-point numbers. The project emphasises reliability and an intuitive API.
+* [Jodo.Numerics](https://github.com/JosephJShort/Jodo/#3-jodonumerics) - Provides fully-featured custom number types, such as fixed-point and clamped numbers. The project emphasises reliability and consistency with the .NET API.
 
 ## Media
 
-* [CSCore](https://github.com/filoe/cscore) - An advanced audio library, supporting playback/recording, decoding/encoding and processing of audio data in realtime (effects, visualizations, ...).
+* [CSdCore](https://github.com/filoe/cscore) - An advanced audio library, supporting playback/recording, decoding/encoding and processing of audio data in realtime (effects, visualizations, ...).
 * [TagLib#](https://github.com/mono/taglib-sharp) - TagLib# (aka taglib-sharp) is a library for reading and writing
 metadata in media files, including video, audio, and photo formats
 * [LibVLCSharp](https://github.com/videolan/libvlcsharp) - Xamarin bindings for libvlc, the multimedia framework powering the VLC applications made by VideoLAN.

--- a/README.md
+++ b/README.md
@@ -791,7 +791,7 @@ the Python world. It uses the Pyro protocol to call methods on remote objects.
 * [AngouriMath](https://github.com/asc-community/AngouriMath) - An open-source symbolic/computer algebra library, made primarily for C# and F#. It covers a range of features and might be considered as an alternative to SymPy in .NET.
 * [Vim.Math3d](https://github.com/vimaec/math3d) - A feature-rich cross-platform replacement for System.Numerics with support for consistent serialization and binary layout, and additional structures and algorithms for efficient 3D Math. 
 * [WPF-Math](https://github.com/ForNeVeR/wpf-math) - a .NET library for rendering mathematical formulae using the LaTeX typesetting style, for the WPF framework
-* [Jodo.Numerics](https://github.com/JosephJShort/Jodo/#3-jodonumerics) - Provides a fully-featured generic interface for number types, supporting operators, math, conversion, parsing, random generation etc. Comes with several custom number types including fixed-point and non-overflowing numbers.
+* [Jodo.Numerics](https://github.com/JosephJShort/Jodo/#3-jodonumerics) - Provides a fully-featured generic interface for number types, supporting operators, math, conversion, parsing, random generation etc. Includes several custom number types such as fixed-point and non-overflowing numbers.
 
 ## Media
 

--- a/README.md
+++ b/README.md
@@ -791,7 +791,7 @@ the Python world. It uses the Pyro protocol to call methods on remote objects.
 * [AngouriMath](https://github.com/asc-community/AngouriMath) - An open-source symbolic/computer algebra library, made primarily for C# and F#. It covers a range of features and might be considered as an alternative to SymPy in .NET.
 * [Vim.Math3d](https://github.com/vimaec/math3d) - A feature-rich cross-platform replacement for System.Numerics with support for consistent serialization and binary layout, and additional structures and algorithms for efficient 3D Math. 
 * [WPF-Math](https://github.com/ForNeVeR/wpf-math) - a .NET library for rendering mathematical formulae using the LaTeX typesetting style, for the WPF framework
-* [Jodo.Numerics](https://github.com/JosephJShort/Jodo/#3-jodonumerics) - Provides a fully-featured generic interface for defining customer number types, along with examples such as fixed-point numbers. The project emphasises reliability and an intuitive API.
+* [Jodo.Numerics](https://github.com/JosephJShort/Jodo/#3-jodonumerics) - Provides a fully-featured generic interface for defining customer number types with examples such as fixed-point numbers. The project emphasises reliability and an intuitive API.
 
 ## Media
 

--- a/README.md
+++ b/README.md
@@ -791,7 +791,7 @@ the Python world. It uses the Pyro protocol to call methods on remote objects.
 * [AngouriMath](https://github.com/asc-community/AngouriMath) - An open-source symbolic/computer algebra library, made primarily for C# and F#. It covers a range of features and might be considered as an alternative to SymPy in .NET.
 * [Vim.Math3d](https://github.com/vimaec/math3d) - A feature-rich cross-platform replacement for System.Numerics with support for consistent serialization and binary layout, and additional structures and algorithms for efficient 3D Math. 
 * [WPF-Math](https://github.com/ForNeVeR/wpf-math) - a .NET library for rendering mathematical formulae using the LaTeX typesetting style, for the WPF framework
-* [Jodo.Numerics](https://github.com/JosephJShort/Jodo/#3-jodonumerics) - Provides fully-featured custom number types, such as fixed-point and clamped numbers. The project emphasises reliability and consistency with the .NET API.
+* [Jodo.Numerics](https://github.com/JosephJShort/Jodo/#3-jodonumerics) - Provides a fully-featured generic interface for number types, supporting operators, math, conversion, parsing, random generation etc. Comes with several custom number types including fixed-point and non-overflowing numbers.
 
 ## Media
 

--- a/README.md
+++ b/README.md
@@ -791,7 +791,7 @@ the Python world. It uses the Pyro protocol to call methods on remote objects.
 * [AngouriMath](https://github.com/asc-community/AngouriMath) - An open-source symbolic/computer algebra library, made primarily for C# and F#. It covers a range of features and might be considered as an alternative to SymPy in .NET.
 * [Vim.Math3d](https://github.com/vimaec/math3d) - A feature-rich cross-platform replacement for System.Numerics with support for consistent serialization and binary layout, and additional structures and algorithms for efficient 3D Math. 
 * [WPF-Math](https://github.com/ForNeVeR/wpf-math) - a .NET library for rendering mathematical formulae using the LaTeX typesetting style, for the WPF framework
-* [Jodo.Numerics](https://github.com/JosephJShort/Jodo/#numerics) - Provides extra number types (such as fixed-point and non-overflowing) with full support for operators, math, conversion, parsing etc. Extensively tested, and cross-platform compatible.
+* [Jodo.Numerics](https://github.com/JosephJShort/Jodo/#numerics) - Provides extra number types (such as fixed-point and non-overflowing numbers) with full support for operators, math, string-parsing etc. Extensively tested, and cross-platform compatible.
 
 ## Media
 

--- a/README.md
+++ b/README.md
@@ -791,7 +791,7 @@ the Python world. It uses the Pyro protocol to call methods on remote objects.
 * [AngouriMath](https://github.com/asc-community/AngouriMath) - An open-source symbolic/computer algebra library, made primarily for C# and F#. It covers a range of features and might be considered as an alternative to SymPy in .NET.
 * [Vim.Math3d](https://github.com/vimaec/math3d) - A feature-rich cross-platform replacement for System.Numerics with support for consistent serialization and binary layout, and additional structures and algorithms for efficient 3D Math. 
 * [WPF-Math](https://github.com/ForNeVeR/wpf-math) - a .NET library for rendering mathematical formulae using the LaTeX typesetting style, for the WPF framework
-* [Jodo.Numerics](https://github.com/JosephJShort/Jodo/#numerics) - Provides a fully-featured generic interface for number types, supporting operators, math, conversion, parsing, random generation etc. Includes several custom number types such as fixed-point and non-overflowing numbers.
+* [Jodo.Numerics](https://github.com/JosephJShort/Jodo/#numerics) - Provides extra number types (such as fixed-point and non-overflowing) with full support for operators, math, conversion, parsing etc. Extensively tested, and cross-platform compatible.
 
 ## Media
 


### PR DESCRIPTION
Mathematics/Jodo.Numerics - [https://github.com/JosephJShort/Jodo/#numerics](https://github.com/JosephJShort/Jodo/#numerics)

Provides extra number types (such as fixed-point and non-overflowing) with full support for operators, math, conversion, parsing etc. Extensively tested, and cross-platform compatible.

## Notes

Hello there, I'm a .NET developer making a few open-source packages. I would love to include **Jodo.Numerics** on this awesome list so that it can be helpful to others, and so that I can gain feedback for future versions.

I'd be very happy to incorporate any feedback you have on the wording in my description.

Here are some notes regarding the quality standard in the contributions guide:

<br />

> Actively maintained (even if that just means acknowledging open issues when they arise)

The project has a [roadmap](https://github.com/JosephJShort/Jodo/#roadmap) and an [issues backlog](https://github.com/JosephJShort/Jodo/issues).

<br />

> Stable

The project has [one stable version (1.0.0)](https://www.nuget.org/packages?q=Jodo.) released on NuGet.

<br />

> Documented

The project has a detailed [README.md](https://github.com/JosephJShort/Jodo/blob/main/README.md), and [partial API documentation](https://jodo.dev/html/N_Jodo_Numerics.htm).

<br />

> Tests

The project has an extensive suite of tests (see a [recent run](https://dev.azure.com/JosephJShort/Jodo/_build/results?buildId=249&view=ms.vss-test-web.build-test-results-tab)) and uses [Azure DevOps](https://dev.azure.com/JosephJShort/Jodo/_build) for continuous integration. [SonarCloud](https://sonarcloud.io/summary/overall?id=JosephJShort_Jodo) and [CodeFactor](https://www.codefactor.io/repository/github/josephjshort/jodo/overview/main) are also used.

<br />

> Generally useful to the community

Remains to be seen. I'll let the reviewers decide.


<br />

Thanks,
Joe