### PR TITLE
docs: Update Testcontainers to official project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1145,7 +1145,7 @@ metadata in media files, including video, audio, and photo formats
 * [NSubstitute](https://nsubstitute.github.io/) - A friendly substitute for .NET mocking frameworks
 * [NUnit](https://github.com/nunit/nunit) - A unit-testing framework for all .NET languages
 * [Rhino Mocks](https://github.com/ayende/rhino-mocks) - Dynamic Mocking Framework for .NET
-* [TestContainers dotnet](https://github.com/isen-ng/testcontainers-dotnet) - Testcontainers is a dotnet standard 2.0 library that supports NUnit and XUnit tests, providing lightweight, throwaway instances of common databases or anything else that can run in a Docker container.
+* [Testcontainers](https://github.com/testcontainers/testcontainers-dotnet) - A library to support tests with throwaway instances of Docker containers for all compatible .NET Standard versions.
 * [Shouldly](https://github.com/shouldly/shouldly) - Shouldly is an assertion framework which focuses on giving great error messages when the assertion fails while being simple and terse.
 * [Snapshooter](https://github.com/SwissLife-OSS/snapshooter) - A snapshot testing tool for .NET Core and .NET Framework
 * [SpecFlow](https://github.com/SpecFlowOSS/SpecFlow) - Binding business requirements to .Net code


### PR DESCRIPTION
Testing/Testcontainers - [Testcontainers](https://github.com/testcontainers/testcontainers-dotnet)

A library to support tests with throwaway instances of Docker containers for all compatible .NET Standard versions.

## Why is it important?

The PR updates the link to the official repository. We [consolidated](https://github.com/testcontainers/testcontainers-dotnet-legacy/issues/91#issuecomment-1155363211) the projects a few months ago.

<!--
  Please, fill in this PR template. It will help maintainers to do the review.
  Also, please read our [Contribution guidelines](CONTRIBUTING.md). 
  Please, create one pull request per link.
-->
