### PR TITLE
Added link of ASP.NET Core Developer Roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -1298,3 +1298,4 @@ metadata in media files, including video, audio, and photo formats
 * [Discover .NET](https://discoverdot.net) - Awesome .NET open source and community resources.
 * [NuGet Trends](https://nugettrends.com) - Check out NuGet packages adoption and what's trending on NuGet.
 * [Weekly C# Digest](https://csharpdigest.net/) - Weekly email newsletter with manually curated top 5 links from the .NET community.
+* [ASP.NET Core Developer Roadmap](https://roadmap.sh/aspnet-core) - A complete guide to become a ASP.NET Developer.


### PR DESCRIPTION
Hi @quozd,

I came across your repository [awesome-dotnet](https://github.com/quozd/awesome-dotnet) and found it to be a valuable resource for ASP.NET enthusiasts.

While browsing through the repository, I noticed that it was missing links to any structured guides such as the famous ["ASP.NET Core Developer Roadmap"](https://roadmap.sh/aspnet-core). I took the initiative to submit a ["Pull Request"](https://github.com/quozd/awesome-dotnet/pull/1145) adding it in Resources section.

Thank you for your time and effort in maintaining this valuable resource :)

Best,
Mouaaz