### PR TITLE
Revert "Add Topaz OSS Authz"

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,6 @@ To the extent possible under law, [Vitali Fokin](https://github.com/quozd) has w
 * [IdentityServer](https://github.com/IdentityServer) - Extensible OAuth2 and OpenID Connect provider framework.
 * [OAuth](https://github.com/danielcrenna/vault/tree/master/oauth) - A very lightweight library for generating OAuth 1.0a signatures written in C#
 * [Stuntman](https://rimdev.io/stuntman/) - Stuntman is a library for impersonating users during development leveraging .NET Claims Identity.
-* [Topaz](https://www.topaz.sh) - An open-source authorization project for .NET applications.  
 
 ## Blazor
 


### PR DESCRIPTION
Reverts quozd/awesome-dotnet#1169

Topaz is a Go lang project. Whilst it has a dotnet SDK, the link points to https://github.com/aserto-dev/aserto-dotnet/. I'm unsure of the relationship with aserto-dev. 

Removing for now