### PR TITLE
[Markdown] Cleanup: Remove CommonMark listing as it's no longer maintained

### DIFF
--- a/README.md
+++ b/README.md
@@ -792,7 +792,6 @@ the Python world. It uses the Pyro protocol to call methods on remote objects.
 ## Markdown Processors
 * [MarkdownSharp](https://code.google.com/archive/p/markdownsharp) - Open source C# implementation of Markdown processor, as featured on Stack Overflow.
 * [F# Formatting](https://fsprojects.github.io/FSharp.Formatting/) - Tools for documenting F# and C# projects.  The library contains extensible Markdown parser as a core component.
-* [CommonMark.NET](https://github.com/Knagis/CommonMark.NET) - Implementation of CommonMark specification in C# for converting Markdown documents to HTML. Optimized for maximum performance and portability.
 * [markdig](https://github.com/lunet-io/markdig) - A fast, powerful, CommonMark compliant, extensible Markdown processor for .NET.
 
 ## Mail


### PR DESCRIPTION
CommonMark is no longer maintained and it's recommended to use MarkDig instead. Updating this list to reflect that.

https://github.com/Knagis/CommonMark.NET

