### PR TITLE
Add QPdfSharp

### DIFF
--- a/README.md
+++ b/README.md
@@ -961,6 +961,7 @@ metadata in media files, including video, audio, and photo formats
 
 ## PDF
 
+* [QPdfSharp](https://github.com/svengeance/QPdfSharp) - A C# wrapper written around QPdf to allow for easy PDF manipulation that is tested for both linux and windows. QPdf is one of the only libraries capable of PDF linearization, and this wrapper ensures you keep up to date with the underlying improvements.
 * [Cloudmersive PDF](https://cloudmersive.com/pdf-api) - Cloudmersive PDF is a native .NET Framework and .NET Core NuGet library and API service that can create, modify, encrypt or convert PDF documents at high scale and fidelity; and is free to use with no expiration **[Free]**
 * [Docotic.Pdf](https://bitmiracle.com/pdf-library/) - PDF library to create, read, edit, draw, and print PDF documents in .NET and .NET Core applications. 100% managed, without unsafe blocks. **[$]** **[[Free for OSS](https://bitmiracle.com/pdf-library/free-pdf-library.aspx)]**
 * [ITextSharp](https://github.com/itext/itextsharp) - iText is a PDF library that allows you to CREATE, ADAPT, INSPECT and MAINTAIN documents in the Portable Document Format (PDF)**[$]** **[Free for OSS]**


### PR DESCRIPTION
PDF/QPdfSharp - https://github.com/svengeance/QPdfSharp - QPdf: https://github.com/qpdf/qpdf/

_Disclaimer: am author_

A C# wrapper written around QPdf to allow for easy PDF manipulation that is tested for both linux and windows. 

What sets this wrapper apart from others so far is that I've created GH actions that run daily to check for underlying updates to the QPdf library and publish runtime libraries in NuGet, allowing devs to take full advantage of updates as they choose. The library isn't fully wrapped, but it will be in the short future.

_QPdf, the wrapped library_
QPdf is a command-line tool and C++ library that performs content-preserving transformations on PDF files. It supports linearization, encryption, and numerous other features. It can also be used for splitting and merging files, creating PDF files (but you have to supply all the content yourself), and inspecting files for study or analysis. QPdf does not render PDFs or perform text extraction, and it does not contain higher-level interfaces for working with page contents. It is a low-level tool for working with the structure of PDF files and can be a valuable tool for anyone who wants to do programmatic or command-line-based manipulation of PDF files.