### PR TITLE
Add 'NibblePoker.Library.Arguments' in 'CLI' section

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,7 @@ To the extent possible under law, [Vitali Fokin](https://github.com/quozd) has w
 * [RunInfoBuilder](https://github.com/rushfive/RunInfoBuilder) - A unique command line parser, utilizing object trees for commands.
 * [SharpNetSH](https://github.com/rpetz/SharpNetSH) - A simple netsh library for C#.
 * [spectre.console](https://github.com/spectresystems/spectre.console) - A library that makes it easier to create beautiful console applications.
+* [NibblePoker.Library.Arguments](https://github.com/aziascreations/DotNet-Arguments) - A lightweight library to parse launch arguments with support for git-like verbs.
 
 ## CLR
 


### PR DESCRIPTION
CLI/NibblePoker.Library.Arguments - [aziascreations/DotNet-Arguments](https://github.com/aziascreations/DotNet-Arguments)

A lightweight library to parse launch arguments with support for git-like verbs.

<br>

Review bullet points:
* Close-to-standard CLI args parsing behavior, decent verb support, and complete help text printer
* Completely documented (https://aziascreations.github.io/DotNet-Arguments/)
* Completely tested
* Some copy/paste examples present
* Actively kept in sync with a C port (https://github.com/aziascreations/C99-Utility-Libraries)
* Used & tested in [other project of mine](https://github.com/aziascreations/DotNet-ListComPort)