### PR TITLE
Added xsl-transformer CLI tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,7 @@ To the extent possible under law, [Vitali Fokin](https://github.com/quozd) has w
 * [RunInfoBuilder](https://github.com/rushfive/RunInfoBuilder) - A unique command line parser, utilizing object trees for commands.
 * [SharpNetSH](https://github.com/rpetz/SharpNetSH) - A simple netsh library for C#.
 * [spectre.console](https://github.com/spectresystems/spectre.console) - A library that makes it easier to create beautiful console applications.
+* [xsl-transformer](https://github.com/armanossiloko/xsl-transformer) - A simple CLI tool that transforms XML data files into human / browser readable content (e.g HTML) using the XSL transformations.
 
 ## CLR
 


### PR DESCRIPTION
CLI/xsl-transformer - [https://github.com/armanossiloko/xsl-transformer](https://github.com/armanossiloko/xsl-transformer)

`xsl-transformer` is a simple CLI tool which allows transforming XML data into readable output content such as HTML using the XSL transform technique.

e.g A notable example (and the root cause of its creation) are IIS logs in XML format which used to be readable by simply opening them in Internet Explorer. That, however, has become harder with IE's retirement and opening any of those logs would result in viewing raw XML data, rather than an HTML formatted document.