### PR TITLE
Add GenHTTP to web server section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1287,7 +1287,7 @@ metadata in media files, including video, audio, and photo formats
 ## Web Servers
 
 * [EmbedIO](https://github.com/unosquare/embedio) - Web server built on Mono and cross-platform
-* [GenHTTP](https://genhttp.org) - A lightweight, embeddable web server for quickly creating REST APIs
+* [GenHTTP](https://github.com/Kaliumhexacyanoferrat/GenHTTP) - A lightweight, embeddable web server for quickly creating REST APIs
 * [SimpleW](https://github.com/stratdev3/SimpleW) - Simple Web Server, build your RestAPI, fast, lightweight and cross-platform. 
 * [XSP](https://github.com/mono/xsp) - Mono's ASP.NET hosting server. This module includes an Apache Module, a FastCGI module that can be hooked to other web servers as well as a standalone server used for testing (similar to Microsoft's Cassini)
 

--- a/README.md
+++ b/README.md
@@ -1287,6 +1287,7 @@ metadata in media files, including video, audio, and photo formats
 ## Web Servers
 
 * [EmbedIO](https://github.com/unosquare/embedio) - Web server built on Mono and cross-platform
+* [GenHTTP](https://genhttp.org) - A lightweight, embeddable web server for quickly creating REST APIs
 * [SimpleW](https://github.com/stratdev3/SimpleW) - Simple Web Server, build your RestAPI, fast, lightweight and cross-platform. 
 * [XSP](https://github.com/mono/xsp) - Mono's ASP.NET hosting server. This module includes an Apache Module, a FastCGI module that can be hooked to other web servers as well as a standalone server used for testing (similar to Microsoft's Cassini)
 


### PR DESCRIPTION
Web Servers / GenHTTP - https://genhttp.org

A lightweight, embeddable web server for quickly creating REST APIs