### PR TITLE
Add CodeLineCounter tool to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,6 +337,7 @@ To the extent possible under law, [Vitali Fokin](https://github.com/quozd) has w
 * [Codinion](https://www.codinion.com/) - Enhanced syntax highlighting for C# and some other "Visual" features. **[$]**
 * [NsDepCop](https://github.com/realvizu/NsDepCop) - Static code analysis tool to enforce namespace dependency rules in C# projects.
 * [WebBen](https://github.com/omerfarukz/WebBen) - Is a tool for benchmarking your Hypertext Transfer Protocol (HTTP) server.
+* [CodeLineCounter](https://github.com/magic5644/codeLineCounter) - Is a tool to analyze .NET projects and extract some metrics (number of code lines, cognitive complexity, duplication codes, dependency analysis, etc.)
 
 ## Code Snippets
 


### PR DESCRIPTION
Code analytics and Metrics/Application - [CodeLineCounter](https://github.com/magic5644/codeLineCounter)

PROJECT_DESCRIPTION

The CodeLineCounter project is a tool that counts the number of lines of code per file, namespace, and project in a .NET solution. It also calculates the cyclomatic complexity of each file.

Since version 1.0.2 it also check duplications in the code. Since version 1.2.0 it also generate duplication report.

All the results are exported to CSV or JSON files. A Graph of dependency is also generated. (dot file Graphviz format)
