### PR TITLE
Add FastLZMA2NET

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,6 +379,7 @@ To the extent possible under law, [Vitali Fokin](https://github.com/quozd) has w
 * [SharpZipLib](https://icsharpcode.github.io/SharpZipLib/) - a Zip, GZip, Tar and BZip2 library written entirely in C# for the .NET platform
 * [Snappy for Windows](https://snappy.machinezoo.com/) - Snappy compression library for .NET baked on P/Invoke
 * [Snappy.Sharp](https://github.com/jeffesp/Snappy.Sharp) - An implementation of Google's Snappy compression algorithm in C#.
+* [FastLZMA2NET](https://github.com/kingsznhone/FastLZMA2Net) - A .NET Wrapper of [Fast LZMA2 Algorithm](https://github.com/conor42/fast-lzma2).
 
 ## Configuration
 * [AgileConfig](https://github.com/dotnetcore/AgileConfig) - AgileConfig is a lightweight configuration center that helps you manage all your application's configurations through website.


### PR DESCRIPTION
Compression/FastLZMA2NET - [FastLZMA2NET](https://github.com/kingsznhone/FastLZMA2Net)

PROJECT_DESCRIPTION

Fast LZMA2 is a enhancement of original LZMA2. The library uses a parallel buffered radix match-finder and some optimizations from Zstandard to achieve a 20% to 100% speed gain at the higher levels over the default LZMA2 algorithm.

This dotnet wrapper use original native dll as compression core, provide highest performance and easy-to-use encapsulation api on dotnet plaform.

### benchmark
Benchmark on C&C Red Alert 2 game folder, which have mixed binary and text data.

![](https://github.com/kingsznhone/FastLZMA2Net/raw/main/readme/benchmark.png)