### PR TITLE
Add HubDocs: Swagger-like UI for SignalR hubs

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,6 +422,7 @@ To the extent possible under law, [Vitali Fokin](https://github.com/quozd) has w
 * [F# Formatting](https://fsprojects.github.io/FSharp.Formatting/) - Tools for documenting F# and C# projects from F# script files, Markdown documents and inline XML or Markdown comments
 * [DocFX](https://github.com/dotnet/docfx) - Tools for building and publishing API documentation for .NET projects
 * [DocNet](https://github.com/FransBouma/DocNet) - Your friendly static documentation generator, using markdown files to build the content.
+* [HubDocs](https://github.com/mberrishdev/HubDocs) - Swagger-like UI tool like Swagger, but for SignalR hubs — auto-discover your hubs, explore methods, invoke calls, and preview live client messages..
 
 ## E-Commerce and Payments
 


### PR DESCRIPTION
HubDocs is a dev tool that auto-documents SignalR hubs, allowing live testing and client event monitoring, similar to Swagger but for real-time hubs.