### PR TITLE
Update Web Servers/SimpleW project url

### DIFF
--- a/README.md
+++ b/README.md
@@ -1072,7 +1072,7 @@ metadata in media files, including video, audio, and photo formats
 
 * [EmbedIO](https://github.com/unosquare/embedio) - Web server built on Mono and cross-platform
 * [GenHTTP](https://github.com/Kaliumhexacyanoferrat/GenHTTP) - A lightweight, embeddable web server for quickly creating REST APIs
-* [SimpleW](https://github.com/stratdev3/SimpleW) - Simple Web Server, build your RestAPI, fast, lightweight and cross-platform. 
+* [SimpleW](https://stratdev3.github.io/SimpleW) - Web server Library in .NET Core. Powerfully Simple, Blazingly Fast and Build-in components (API REST, JWT, Websockets, self-serialization, Opentelemetry).
 
 ## WebSocket
 


### PR DESCRIPTION
The SimpleW project has a new documentation site.

Web Servers/SimpleW - [https://stratdev3.github.io/SimpleW](https://stratdev3.github.io/SimpleW)

Web server Library in .NET Core. Powerfully Simple, Blazingly Fast and Build-in components (API REST, JWT, Websockets, self-serialization, Opentelemetry).
