### PR TITLE
Add NaturalCron to Scheduling section

### DIFF
--- a/README.md
+++ b/README.md
@@ -910,7 +910,7 @@ metadata in media files, including video, audio, and photo formats
 * [Occurify](https://github.com/Occurify/Occurify) - A powerful and intuitive .NET library for defining, filtering, transforming, and scheduling instant and period timelines.
 * [TickerQ](https://github.com/Arcenox-co/TickerQ) - Lightweight, high-performance, reflection-free job scheduler for .NET with EF Core, cron/time-based execution, custom locking, and retry support.
 * [NCronJob](https://github.com/NCronJob-Dev/NCronJob) - A Job Scheduler sitting on top of IHostedService in dotnet.
-* [RecurlyEx](https://github.com/hugoj0s3/RecurlyEx) – Human-readable scheduling library for .NET using natural-language expressions.
+* [NaturalCron](https://github.com/hugoj0s3/NaturalCron) – Human-readable scheduling library for .NET using natural-language expressions.
 
 
 ## SDK and API Clients

--- a/README.md
+++ b/README.md
@@ -910,6 +910,8 @@ metadata in media files, including video, audio, and photo formats
 * [Occurify](https://github.com/Occurify/Occurify) - A powerful and intuitive .NET library for defining, filtering, transforming, and scheduling instant and period timelines.
 * [TickerQ](https://github.com/Arcenox-co/TickerQ) - Lightweight, high-performance, reflection-free job scheduler for .NET with EF Core, cron/time-based execution, custom locking, and retry support.
 * [NCronJob](https://github.com/NCronJob-Dev/NCronJob) - A Job Scheduler sitting on top of IHostedService in dotnet.
+* [RecurlyEx](https://github.com/hugoj0s3/RecurlyEx) – Human-readable scheduling library for .NET using natural-language expressions.
+
 
 ## SDK and API Clients
 


### PR DESCRIPTION
Scheduling/NaturalCron- [https://github.com/hugoj0s3/NaturalCron](https://github.com/hugoj0s3/NaturalCron)

Added NaturalCron to the Scheduling section. NaturalCron is a C# library for defining recurring events using natural, human-readable expressions with features like timezone support and flexible filters.



