### PR TITLE
Add PosInformatique.Moq.Analyzers in the "Compilers, Transpilers and Languages" category.

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,6 +306,7 @@ To the extent possible under law, [Vitali Fokin](https://github.com/quozd) has w
 * [Bencher](https://bencher.dev/) - Suite of continuous benchmarking tools designed to catch performance regressions in CI.
 * [NsDepCop](https://github.com/realvizu/NsDepCop) - Static code analysis tool to enforce namespace dependency rules in C# projects.
 * [WebBen](https://github.com/omerfarukz/WebBen) - Is a tool for benchmarking your Hypertext Transfer Protocol (HTTP) server.
+* [PosInformatique.Moq.Analyzers](https://github.com/PosInformatique/PosInformatique.Moq.Analyzers) - A set of code analyzers to verify syntax and code design when writing the unit tests using the [Moq](https://github.com/devlooped/moq) library.
 
 ## Code Snippets
 


### PR DESCRIPTION
Compilers, Transpilers and Languages/PosInformatique.Moq.Analyzers - [PosInformatique.Moq.Analyzers](https://github.com/PosInformatique/PosInformatique.Moq.Analyzers)

[PosInformatique.Moq.Analyzers](https://github.com/PosInformatique/PosInformatique.Moq.Analyzers)) is a set of analyzers to verify syntax and code design when writing the unit tests using the [Moq](https://github.com/devlooped/moq) library.
This set of analyzers analyze the code to check some errors during the compilation to be sure that the execution of the unit tests with `Mock<T>` instances will not raise exceptions.

:dart: It helps developers save time to check their [Moq](https://github.com/devlooped/moq) setup errors during the coding and not after running their unit tests.