### PR TITLE
Add RCParsing into Parser Library section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1125,6 +1125,7 @@ metadata in media files, including video, audio, and photo formats
 * [Superpower](https://github.com/datalust/superpower) - A C# parser construction toolkit with high-quality error reporting
 * [CSLY](https://github.com/b3b00/CSLY) - A light embedded C# lexer/parser generator.
 * [Parakeet](https://github.com/ara3d/parakeet) - A recursive descent parsing library with operator overloading for C#.
+* [RCParsing](https://github.com/RomeCore/RCParsing) - A lexerless parser builder with a BNF-style Fluent API and barrier tokens for indentation-sensitive languages (Python/YAML).
   
 ## Source Generator
 


### PR DESCRIPTION
Parser Library/RCParsing - [RCParsing](https://github.com/RomeCore/RCParsing)

This is the parser framework that focuses on developer experience first, providing a huge toolkit for making own DSLs of any complexity or even text scrappers. It highlights with these features:

- Ability to parse indent-based languages like Python and YAML with barrier tokens.
- Mode for finding all matches in the text, just like the regex.
- Performance that comparable with Pidgin, which known as one of fastest parser-combinators in the .NET.
- Big set of useful parsing primitives: numbers with configurable flags, escaped text with auto-unescaping, separated lists with ability to allow trailing separator, and more...
- Very detailed documentation with examples and 99% of XML docstrings coverage.

It has been tested on 80+ of test methods and has been already used in one of my projects. It actively maintained.