### PR TITLE
Add SmartCovers to Media

### DIFF
--- a/README.md
+++ b/README.md
@@ -724,7 +724,7 @@ the Python world. It uses the Pyro protocol to call methods on remote objects.
 * [CSCore](https://github.com/filoe/cscore) - An advanced audio library, supporting playback/recording, decoding/encoding and processing of audio data in realtime (effects, visualizations, ...).
 * [TagLib#](https://github.com/mono/taglib-sharp) - TagLib# (aka taglib-sharp) is a library for reading and writing
 metadata in media files, including video, audio, and photo formats
-* [jellyfin-plugin-book-cover](https://github.com/GeiserX/jellyfin-plugin-book-cover) - Jellyfin plugin for fallback cover extraction from PDF, EPUB, and audiobook files using Google Books and Open Library.
+* [jelly-covers](https://github.com/GeiserX/jelly-covers) - Jellyfin plugin for cover extraction from books, audiobooks, comics, magazines, and music libraries with online fallback via Open Library & Google Books.
 * [LibVLCSharp](https://github.com/videolan/libvlcsharp) - Xamarin bindings for libvlc, the multimedia framework powering the VLC applications made by VideoLAN.
 * [NAudio](https://github.com/naudio/NAudio) - Playback, decode and encode audio in a variety of file formats such as MP3, MP4, WAV, AIFF, Speex, etc.
 * [Xabe.FFmpeg](https://github.com/tomaszzmuda/Xabe.FFmpeg) - .NET Standard wrapper for FFmpeg. It allows to process media without know how FFmpeg works, and can be used to pass customized arguments to FFmpeg from C# application. **[$]**

--- a/README.md
+++ b/README.md
@@ -724,6 +724,7 @@ the Python world. It uses the Pyro protocol to call methods on remote objects.
 * [CSCore](https://github.com/filoe/cscore) - An advanced audio library, supporting playback/recording, decoding/encoding and processing of audio data in realtime (effects, visualizations, ...).
 * [TagLib#](https://github.com/mono/taglib-sharp) - TagLib# (aka taglib-sharp) is a library for reading and writing
 metadata in media files, including video, audio, and photo formats
+* [jellyfin-plugin-book-cover](https://github.com/GeiserX/jellyfin-plugin-book-cover) - Jellyfin plugin for fallback cover extraction from PDF, EPUB, and audiobook files using Google Books and Open Library.
 * [LibVLCSharp](https://github.com/videolan/libvlcsharp) - Xamarin bindings for libvlc, the multimedia framework powering the VLC applications made by VideoLAN.
 * [NAudio](https://github.com/naudio/NAudio) - Playback, decode and encode audio in a variety of file formats such as MP3, MP4, WAV, AIFF, Speex, etc.
 * [Xabe.FFmpeg](https://github.com/tomaszzmuda/Xabe.FFmpeg) - .NET Standard wrapper for FFmpeg. It allows to process media without know how FFmpeg works, and can be used to pass customized arguments to FFmpeg from C# application. **[$]**

--- a/README.md
+++ b/README.md
@@ -724,7 +724,7 @@ the Python world. It uses the Pyro protocol to call methods on remote objects.
 * [CSCore](https://github.com/filoe/cscore) - An advanced audio library, supporting playback/recording, decoding/encoding and processing of audio data in realtime (effects, visualizations, ...).
 * [TagLib#](https://github.com/mono/taglib-sharp) - TagLib# (aka taglib-sharp) is a library for reading and writing
 metadata in media files, including video, audio, and photo formats
-* [jelly-covers](https://github.com/GeiserX/jelly-covers) - Jellyfin plugin for cover extraction from books, audiobooks, comics, magazines, and music libraries with online fallback via Open Library & Google Books.
+* [SmartCovers](https://github.com/GeiserX/smart-covers) - Jellyfin plugin for fallback cover extraction from PDF, EPUB, and audiobook files.
 * [LibVLCSharp](https://github.com/videolan/libvlcsharp) - Xamarin bindings for libvlc, the multimedia framework powering the VLC applications made by VideoLAN.
 * [NAudio](https://github.com/naudio/NAudio) - Playback, decode and encode audio in a variety of file formats such as MP3, MP4, WAV, AIFF, Speex, etc.
 * [Xabe.FFmpeg](https://github.com/tomaszzmuda/Xabe.FFmpeg) - .NET Standard wrapper for FFmpeg. It allows to process media without know how FFmpeg works, and can be used to pass customized arguments to FFmpeg from C# application. **[$]**


### PR DESCRIPTION
## Summary
- Adds [SmartCovers](https://github.com/GeiserX/smart-covers) to the Media section.
- Jellyfin plugin (.NET/C#) for fallback cover extraction from PDF, EPUB, and audiobook files.
- Entry placed in alphabetical order.