### PR TITLE
Add ReleaseRun NuGet Package Health checker to Package Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -852,6 +852,7 @@ metadata in media files, including video, audio, and photo formats
 
 ## Package Management
 
+* [ReleaseRun NuGet Package Health](https://releaserun.com/tools/nuget-package-health/) - A free tool that checks any NuGet package for deprecation status, latest version, and active maintenance with an instant A–F health grade.
 * [NuGet](https://www.nuget.org/) - The .NET package manager
 * [Cloudsmith](https://cloudsmith.com/nuget-feed/) - A fully managed package management SaaS, with support for NuGet, Npm, Docker and much more. **[Free for Public/OSS]** **[$]**
 * [MyGet](https://www.myget.org/) - Hosted Package Repository for NuGet, NPM, Bower and VSIX. Also provides CI as-a-Service. **[$]**


### PR DESCRIPTION
Adds a free web tool for checking NuGet package health — latest version, deprecation status, and A–F health grade. Useful for auditing .NET project dependencies.

URL: https://releaserun.com/tools/nuget-package-health/