### PR TITLE
Add NextFs — Fable bindings for Next.js App Router

### DIFF
--- a/README.md
+++ b/README.md
@@ -1095,6 +1095,7 @@ metadata in media files, including video, audio, and photo formats
 * [Suave.IO](https://suave.io/) - Framework/library/web server that makes you cry tears of joy after finishing your project ahead-of-time when you look at the beautiful code you've written in F#.
 * [DotVVM](https://github.com/riganti/dotvvm) - MVVM framework for people who don't like to write JavaScript, with OWIN and ASP.NET Core support and a free extension for Visual Studio 2015 and 2017.
 * [Giraffe](https://github.com/giraffe-fsharp/Giraffe) - Functional (F#) ASP.NET Core micro framework for building rich web applications
+* [NextFs](https://github.com/Neftedollar/Next.fs) - Fable bindings for Next.js App Router, enabling full-stack F# web apps with React Server Components, typed server fetch, and auto-generated entry wrappers.
 
 ## Web Servers
 


### PR DESCRIPTION
[NextFs](https://github.com/Neftedollar/Next.fs) — Fable bindings for Next.js App Router, enabling full-stack F# web apps with React Server Components.

Covers components, navigation, typed server fetch, cache directives, metadata builders, OG image generation, next/font catalog, proxy config, and auto-generated entry wrappers.

- [NuGet](https://www.nuget.org/packages/NextFs) (v1.0.0)
- [Documentation](https://neftedollar.github.io/Next.fs/)
- MIT license