### PR TITLE
Add Fyper — type-safe Cypher query builder for F# (Neo4j, Apache AGE)

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,6 +393,7 @@ To the extent possible under law, [Vitali Fokin](https://github.com/quozd) has w
 * [Couchbase](https://github.com/couchbase/couchbase-net-client) - Official Couchbase .NET client library, based on the Enyim memcached client
 * [Firebird.NET](https://sourceforge.net/projects/firebird/) - The .NET Data provider is written in C# and provides a high-performance, native implementation of the Firebird API
 * [Rqlite-dotnet](https://github.com/rqlite/rqlite-dotnet) - .NET client for rqlite (distributed relational DB based on SQLite)
+* [Fyper](https://github.com/Neftedollar/fyper) - Type-safe Cypher query builder for F#. Computation expressions for Neo4j and Apache AGE graph databases. Zero dependencies, parameterized by default.
 
 ## Datetime
 


### PR DESCRIPTION
Add [Fyper](https://github.com/Neftedollar/fyper) to the Database Drivers section.

Fyper is a type-safe Cypher query builder for F# that compiles computation expressions into parameterized Cypher strings. Supports Neo4j (Bolt) and Apache AGE (PostgreSQL).

- Zero dependencies in core library
- 250 tests (unit + property-based + integration)
- Published on NuGet: [Fyper](https://www.nuget.org/packages/Fyper), [Fyper.Neo4j](https://www.nuget.org/packages/Fyper.Neo4j), [Fyper.Age](https://www.nuget.org/packages/Fyper.Age), [Fyper.Parser](https://www.nuget.org/packages/Fyper.Parser)
- MIT license