### PR TITLE
Add Quality Gate to Media

### DIFF
--- a/README.md
+++ b/README.md
@@ -726,6 +726,7 @@ the Python world. It uses the Pyro protocol to call methods on remote objects.
 metadata in media files, including video, audio, and photo formats
 * [LibVLCSharp](https://github.com/videolan/libvlcsharp) - Xamarin bindings for libvlc, the multimedia framework powering the VLC applications made by VideoLAN.
 * [NAudio](https://github.com/naudio/NAudio) - Playback, decode and encode audio in a variety of file formats such as MP3, MP4, WAV, AIFF, Speex, etc.
+* [Quality Gate](https://github.com/GeiserX/quality-gate) - Jellyfin plugin that restricts users to specific media versions based on configurable path-based policies for bandwidth management or tiered access.
 * [Xabe.FFmpeg](https://github.com/tomaszzmuda/Xabe.FFmpeg) - .NET Standard wrapper for FFmpeg. It allows to process media without know how FFmpeg works, and can be used to pass customized arguments to FFmpeg from C# application. **[$]**
 * [Sonora](https://github.com/ImAxel0/Sonora) - .NET Audio Framework for audio and MIDI playback, editing, and plugin integration.
 


### PR DESCRIPTION
Adds [Quality Gate](https://github.com/GeiserX/quality-gate) to the Media section.

A Jellyfin plugin that restricts users to specific media versions based on configurable path-based policies — useful for bandwidth management or tiered access control. Built with .NET 9.0, GPL-3.0 licensed.