### PR TITLE
Add PawSharp Discord API wrapper to API section

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ To the extent possible under law, [Vitali Fokin](https://github.com/quozd) has w
 * [FastEndpoints](https://github.com/FastEndpoints/FastEndpoints) - High-performance middleground between classic ASP.NET Core API controllers and Minimal APIs. Using a REPR ([Request-Endpoint-Response](https://deviq.com/design-patterns/repr-design-pattern)) pattern, this library eliminates the boilerplate and monolithic feel of controllers by improving colocation of code. 
 * [Telegram.Bot](https://github.com/TelegramBots/Telegram.Bot) - .NET Client for [Telegram Bot API](https://core.telegram.org/bots/api)
 * [WTelegramClient](https://github.com/wiz0u/WTelegramClient) - Automate a user account on Telegram, using the latest version of [Telegram Client API](https://core.telegram.org/methods)
+* [PawSharp](https://github.com/M1tsumi/PawSharp) - A modern Discord API wrapper for C# with a focus on ease of use and performance.
 * [ASP.NET Web API](https://dotnet.microsoft.com/apps/aspnet/apis) - Framework that makes it easy to build HTTP services that reach a broad range of clients, including browsers and mobile devices
 * [Breeze](https://breeze.github.io/doc-net/) - API framework enabling rich data access by using the OData 3 protocol. Client libraries available for JavaScript and C#.
 * [Mobius: C# API for Spark](https://github.com/Microsoft/Mobius) - Mobius adds C# language binding to Apache Spark, enabling the implementation of Spark driver code and data processing operations in C#.


### PR DESCRIPTION
### What library are you adding?

**PawSharp** - https://github.com/M1tsumi/PawSharp

### In which category should it be added?

SDK and API Clients

### Why is it awesome?

PawSharp is a lightweight, native C# wrapper for the Discord API. It provides a clean, modern interface for interacting with Discord's REST and WebSocket endpoints, ideal for building bots, self-bots, or rich Discord integrations.
