### PR TITLE
Add ILNumerics.ONAL to Mathematics section

### DIFF
--- a/README.md
+++ b/README.md
@@ -708,6 +708,7 @@ the Python world. It uses the Pyro protocol to call methods on remote objects.
 
 ## Mathematics
 
+* [ILNumerics.ONAL](https://github.com/ilnumerics/ILNumerics.ONAL) - Open-source numerical array language for .NET with MATLAB-/NumPy-compatible semantics, multidimensional arrays, advanced indexing, complex numbers, FFTs, and linear algebra as native or managed LAPACK transpilation.
 * [MathFlow](https://github.com/Nonanti/MathFlow) - Comprehensive math expression library with symbolic computation support including differentiation, simplification, and equation solving.
 * [MathNet](https://www.mathdotnet.com/) - Math.NET is an open source initiative to build and maintain toolkits covering fundamental mathematics, targeting advanced but also every day needs of .NET developers
 * [Microsoft Automatic Graph Layout](https://github.com/Microsoft/automatic-graph-layout) - A set of tools for graph layout and viewing.

--- a/README.md
+++ b/README.md
@@ -709,6 +709,7 @@ the Python world. It uses the Pyro protocol to call methods on remote objects.
 ## Mathematics
 
 * [ILNumerics.ONAL](https://github.com/ilnumerics/ILNumerics.ONAL) - Open-source numerical array language for .NET with MATLAB-/NumPy-compatible semantics, multidimensional arrays, advanced indexing, complex numbers, FFTs, and linear algebra as native or managed LAPACK transpilation.
+* [ILNumerics](https://ilnumerics.net) - High-performance numerical computing, visualization, and algorithm acceleration platform for .NET, featuring multidimensional arrays, advanced charting, GPU/CPU acceleration, Visual Studio debugging tools, and MATLAB-/NumPy-compatible numerical computing APIs. **[Proprietary]** and **[Free Edition]**
 * [MathFlow](https://github.com/Nonanti/MathFlow) - Comprehensive math expression library with symbolic computation support including differentiation, simplification, and equation solving.
 * [MathNet](https://www.mathdotnet.com/) - Math.NET is an open source initiative to build and maintain toolkits covering fundamental mathematics, targeting advanced but also every day needs of .NET developers
 * [Microsoft Automatic Graph Layout](https://github.com/Microsoft/automatic-graph-layout) - A set of tools for graph layout and viewing.

--- a/README.md
+++ b/README.md
@@ -709,7 +709,6 @@ the Python world. It uses the Pyro protocol to call methods on remote objects.
 ## Mathematics
 
 * [ILNumerics.ONAL](https://github.com/ilnumerics/ILNumerics.ONAL) - Open-source numerical array language for .NET with MATLAB-/NumPy-compatible semantics, multidimensional arrays, advanced indexing, complex numbers, FFTs, and linear algebra as native or managed LAPACK transpilation.
-* [ILNumerics](https://ilnumerics.net) - High-performance numerical computing, visualization, and algorithm acceleration platform for .NET, featuring multidimensional arrays, advanced charting, GPU/CPU acceleration, Visual Studio debugging tools, and MATLAB-/NumPy-compatible numerical computing APIs. **[Proprietary]** and **[Free Edition]**
 * [MathFlow](https://github.com/Nonanti/MathFlow) - Comprehensive math expression library with symbolic computation support including differentiation, simplification, and equation solving.
 * [MathNet](https://www.mathdotnet.com/) - Math.NET is an open source initiative to build and maintain toolkits covering fundamental mathematics, targeting advanced but also every day needs of .NET developers
 * [Microsoft Automatic Graph Layout](https://github.com/Microsoft/automatic-graph-layout) - A set of tools for graph layout and viewing.


### PR DESCRIPTION
Mathematics/ILNumerics.ONAL - [ILNumerics.ONAL](https://github.com/ILNumerics/ILNumerics.ONAL)

ILNumerics.ONAL is the open-sourced language core of ILNumerics, providing multidimensional array programming and the fundamental tools for building maintainable numerical algorithm IP in .NET. Write serious numerical algorithms in .NET — with Matlab/NumPy semantics, industrial robustness, and no vendor lock-in.
