### PR TITLE
Add StoryCADLib to Misc

### DIFF
--- a/README.md
+++ b/README.md
@@ -771,6 +771,7 @@ metadata in media files, including video, audio, and photo formats
 * [dotnet-exec](https://github.com/WeihanLi/dotnet-exec) - A command-line tool for executing C# program without a project file, and you can have your custom entry point other than Main method.
 * [ComputeSharp](https://github.com/Sergio0694/ComputeSharp) - A a .NET library to run C# code in parallel on the GPU through DX12, D2D1, and dynamically generated HLSL compute and pixel shaders.
 * [ILGPU](https://github.com/m4rs-mt/ILGPU) - A JIT (just-in-time) compiler for high-performance GPU programs written in .Net-based languages.
+* [StoryCADLib](https://github.com/storybuilder-org/StoryCAD) - Story outlining library for fiction writing tools: reads and writes StoryCAD outlines, validates story structure, and applies craft frameworks (Hero's Journey, GMC, the 36 Dramatic Situations). Docs and runnable samples at [api.storybuilder.org](https://api.storybuilder.org).
 
 ## MQTT
 


### PR DESCRIPTION
Project link: https://github.com/storybuilder-org/StoryCAD

StoryCADLib is the open-source .NET library behind StoryCAD, a free outlining tool for fiction writers published by the StoryBuilder Foundation, a 501(c)(3) nonprofit. The library reads and writes story outline files, traverses and validates story elements, and applies craft frameworks (Hero's Journey, Goal-Motivation-Conflict, the 36 Dramatic Situations) programmatically.

Why it belongs on the list: it is the only .NET library covering fiction story structure, it is on NuGet (https://www.nuget.org/packages/StoryCADLib, v4.2, .NET 10), documented at https://api.storybuilder.org with six runnable samples, actively maintained, and tested.