### PR TITLE
Add Explyt AI Agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -598,6 +598,7 @@ To the extent possible under law, [Vitali Fokin](https://github.com/quozd) has w
 * [Visual Studio Code](https://code.visualstudio.com/) - Excellent open source editor from Microsoft, based on Electron.
 * [Ionide](http://ionide.io/) - An Atom Editor and Visual Studio Code package suite for cross platform F# development.
 * [Rider](https://www.jetbrains.com/rider/) - A cross-platform C# IDE based on the IntelliJ platform and ReSharper
+  * [Explyt](https://github.com/explyt/explyt) - AI agent for JetBrains Rider - debugger, refactorings, and symbol navigation via IDE for .NET and C# projects. **[$]**
 * [RoslynPad](https://github.com/aelij/RoslynPad) - A simple C# editor based on Roslyn and AvalonEdit.
 * [Consulo](https://consulo.io) - A cross-platform IDE with C# & Java support, fork of IntelliJ IDEA Community Edition
 * [vvvv](https://visualprogramming.net) A visual live-programming environment for .NET **[Free for OSS]**


### PR DESCRIPTION
IDE/Explyt - [Explyt](https://github.com/explyt/explyt) **[$]**

Explyt is an AI agent for JetBrains Rider that uses the IDE itself as a source of facts about the project, not just an LLM with grep/RAG over the codebase. It can run configured tests and builds, navigate symbol usages, inspect connected library/NuGet source code, debug with real variable values and call stacks, and apply IDE refactorings (e.g. semantic rename) instead of plain text search-and-replace - all useful when working with larger C#/.NET codebases in Rider.

It's on the JetBrains Marketplace with 7000+ downloads: https://plugins.jetbrains.com/plugin/27979-explyt-ai-agent

Regarding the proprietary/commercial requirements from CONTRIBUTING.md:
- Free trial is available.
- Public community discussions/support: GitHub Discussions/Issues on https://github.com/explyt/explyt

Happy to move the entry to a different section, or add more detail, if that helps the review.
